### PR TITLE
Create recall.db with restrictive file permissions

### DIFF
--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -511,7 +511,12 @@ def main():
     args = parser.parse_args()
 
     migrate_db_location()
+    new_db = not DB_PATH.exists()
+    old_umask = os.umask(0o077)
     conn = sqlite3.connect(str(DB_PATH))
+    os.umask(old_umask)
+    if new_db:
+        os.chmod(str(DB_PATH), 0o600)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
     create_schema(conn)


### PR DESCRIPTION
sqlite3.connect() creates the DB with the default umask (typically 0022), so ~/.recall.db ends up world-readable at 0644. Since it contains full text of every user/assistant message from all sessions, it should be owner-only.

Sets umask to 0077 before the connect() call and chmod 0600 for new databases. Existing databases are not modified — users can chmod manually if they want.

Tested on macOS with 1,378 indexed sessions — search works correctly after the change.