### PR TITLE
feat: pi sessions and list mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 scripts/__pycache__/
+tests/__pycache__/
+**/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.1
+
+- Make the positional `query` argument optional. When omitted, list every
+  session in the time window without text matching — bypasses FTS entirely
+  and queries the `sessions` table by `(timestamp, source, project)`,
+  sorted by recency. Useful when callers want to enumerate every session
+  in a window rather than search for a term.
+- Output banner reads `Listed N sessions ...` in list mode (vs `Found ...`)
+- Empty-result message reads `No sessions in the time window.` in list mode
+- No schema change. No reindex needed.
+
+### Examples
+
+```bash
+recall --days 7                         # every session in the last week
+recall --days 7 --source pi             # every pi session in the last week
+recall --project ~/my-project --days 30 # this project, last 30 days
+recall "buffer" --days 7                # text-search, unchanged
+```
+
 ## 0.4.0
 
 - Add pi (`mariozechner/pi-coding-agent`) session support — indexes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.0
+
+- Add pi (`mariozechner/pi-coding-agent`) session support — indexes
+  `~/.claude/projects/`, `~/.codex/sessions/`, and `~/.pi/agent/sessions/`
+- Unified search across Claude Code, Codex, and pi sessions
+- Results tagged `[claude]`, `[codex]`, or `[pi]` to show origin
+- `--source` choices now include `pi` (was `claude|codex`)
+- `read_session.py` auto-detects pi format (header `type: "session"` with `cwd`)
+- Pi parser keeps user/assistant text only — skips thinking, toolCall, image,
+  toolResult, bashExecution, custom, custom_message, session_info, model_change,
+  thinking_level_change, compaction, branch_summary, label
+
+### Upgrading from 0.3.x
+
+Run `--reindex` once to pull pi sessions into the index:
+
+```bash
+python3 ~/.claude/skills/recall/scripts/recall.py --reindex "test"
+```
+
 ## 0.3.0
 
 - Add CJK (Japanese, Chinese, Korean) search support via dual-table FTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.0
+
+- Add pi (`earendil-works/pi-coding-agent`) session support — indexes
+  `~/.claude/projects/`, `~/.codex/sessions/`, and `~/.pi/agent/sessions/`
+- Unified search across Claude Code, Codex, and pi sessions
+- Results tagged `[claude]`, `[codex]`, or `[pi]` to show origin
+- `--source` choices now include `pi` (was `claude|codex`)
+- `read_session.py` auto-detects pi format (header `type: "session"` with `cwd`)
+- Pi parser keeps user/assistant text only — skips thinking, toolCall, image,
+  toolResult, bashExecution, custom, custom_message, session_info, model_change,
+  thinking_level_change, compaction, branch_summary, label
+
+### Upgrading from 0.3.x
+
+Run `--reindex` once to pull pi sessions into the index:
+
+```bash
+python3 ~/.claude/skills/recall/scripts/recall.py --reindex "test"
+```
+
 ## 0.3.0
 
 - Add CJK (Japanese, Chinese, Korean) search support via dual-table FTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.1
+
+- Make the positional `query` argument optional. When omitted, list every
+  session in the time window without text matching — bypasses FTS entirely
+  and queries the `sessions` table by `(timestamp, source, project)`,
+  sorted by recency. Useful when callers want to enumerate every session
+  in a window rather than search for a term.
+- Output banner reads `Listed N sessions ...` in list mode (vs `Found ...`)
+- Empty-result message reads `No sessions in the time window.` in list mode
+- No schema change. No reindex needed.
+
+### Examples
+
+```bash
+recall --days 7                         # every session in the last week
+recall --days 7 --source pi             # every pi session in the last week
+recall --project ~/my-project --days 30 # this project, last 30 days
+recall "buffer" --days 7                # text-search, unchanged
+```
+
 ## 0.4.0
 
 - Add pi (`earendil-works/pi-coding-agent`) session support — indexes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # recall
 
-Ever lost a conversation session with Claude Code or Codex and wish you could resume it? This skill lets Claude and your agents search across all your past conversations with full-text search. Builds a SQLite FTS5 index over `~/.claude/projects/` and `~/.codex/sessions/` with BM25 ranking, Porter stemming, CJK support, and incremental updates.
+Ever lost a conversation session with Claude Code, Codex, or pi and wish you could resume it? This skill lets your agents search across all your past conversations with full-text search. Builds a SQLite FTS5 index over `~/.claude/projects/`, `~/.codex/sessions/`, and `~/.pi/agent/sessions/` with BM25 ranking, Porter stemming, CJK support, and incremental updates.
 
 ## Install
 
@@ -8,17 +8,17 @@ Ever lost a conversation session with Claude Code or Codex and wish you could re
 npx skills add arjunkmrm/recall
 ```
 
-Then use `/recall` in Claude Code (or Codex) or ask "find a past session where we talked about foo" (you might need to restart Claude Code).
+Then use `/recall` in Claude Code (or Codex, or pi) or ask "find a past session where we talked about foo" (you might need to restart your agent).
 
 ## How it works
 ### Index
 
 ```
   ~/.claude/projects/**/*.jsonl ──┐
-                                  ├─▶ Index ──▶ ~/.recall.db (SQLite FTS5)
-  ~/.codex/sessions/**/*.jsonl ───┘   [incremental - mtime-based]
-
-
+                                  │
+  ~/.codex/sessions/**/*.jsonl ───┼─▶ Index ──▶ ~/.recall.db (SQLite FTS5)
+                                  │   [incremental - mtime-based]
+  ~/.pi/agent/sessions/**/*.jsonl ┘
 ```
 ### Query
 ```
@@ -43,7 +43,7 @@ Then use `/recall` in Claude Code (or Codex) or ask "find a past session where w
 - CJK messages are selectively indexed into the trigram table; query routing is automatic
 - Skips tool_use, tool_result, thinking, and image blocks
 - Results ranked by BM25 with a slight recency bias (recent sessions get up to a 20% boost, decaying with a 30-day half-life)
-- Results tagged `[claude]` or `[codex]` with highlighted excerpts
+- Results tagged `[claude]`, `[codex]`, or `[pi]` with highlighted excerpts
 - No dependencies — Python 3.9+ stdlib only (sqlite3, json, argparse)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Then use `/recall` in Claude Code (or Codex, or pi) or ask "find a past session 
 - Results tagged `[claude]`, `[codex]`, or `[pi]` with highlighted excerpts
 - No dependencies — Python 3.9+ stdlib only (sqlite3, json, argparse)
 
+## Tests
+
+```bash
+python3 -m unittest discover tests -v
+```
+
+Stdlib `unittest` only — no test deps. Synthetic JSONL fixtures generated
+in `tmpdir` from the suite itself (no fixture files committed). An
+integration test runs against any real pi sessions in `~/.pi/agent/sessions/`
+on the host and is skipped if none are present.
+
 ## Contributing
 
 Found a bug or have an idea? [Open an issue](https://github.com/arjunkmrm/recall/issues) or submit a pull request — contributions are welcome!

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: recall
 description: >
-  Search past Claude Code and Codex sessions. Triggers: /recall, "search old conversations",
+  Search past Claude Code, Codex, and pi sessions. Triggers: /recall, "search old conversations",
   "find a past session", "recall a previous conversation", "search session history",
   "what did we discuss", "remember when we"
 metadata:
   author: arjunkmrm
-  version: "0.3.0"
+  version: "0.4.0"
   license: MIT
 ---
 
-# /recall — Search Past Claude & Codex Sessions
+# /recall — Search Past Claude, Codex & pi Sessions
 
-Search all past Claude Code and Codex sessions using full-text search with BM25 ranking.
+Search all past Claude Code, Codex, and pi sessions using full-text search with BM25 ranking.
 
 ## Usage
 
 ```bash
-python3 ~/.claude/skills/recall/scripts/recall.py QUERY [--project PATH] [--days N] [--source claude|codex] [--limit N] [--reindex]
+python3 ~/.claude/skills/recall/scripts/recall.py QUERY [--project PATH] [--days N] [--source claude|codex|pi] [--limit N] [--reindex]
 ```
 
 ## Examples
@@ -44,6 +44,9 @@ python3 ~/.claude/skills/recall/scripts/recall.py "buffer" --source claude
 # Search only Codex sessions
 python3 ~/.claude/skills/recall/scripts/recall.py "buffer" --source codex
 
+# Search only pi sessions
+python3 ~/.claude/skills/recall/scripts/recall.py "buffer" --source pi
+
 # Force reindex
 python3 ~/.claude/skills/recall/scripts/recall.py --reindex "test"
 ```
@@ -69,6 +72,10 @@ claude --resume SESSION_ID
 # Codex sessions [codex]
 cd /path/to/project
 codex resume SESSION_ID
+
+# Pi sessions [pi]
+cd /path/to/project
+pi --session SESSION_ID         # full or partial id; pi resolves prefix matches
 ```
 
 Each result includes a `File:` path. Use it to read the raw transcript (auto-detects format):
@@ -82,9 +89,10 @@ If results are missing `File:` paths, run `--reindex` to backfill.
 ## Notes
 
 - Index is stored at `~/.recall.db` (SQLite FTS5, auto-migrated from `~/.claude/recall.db`)
-- Indexes both `~/.claude/projects/` (Claude Code) and `~/.codex/sessions/` (Codex)
+- Indexes three sources: `~/.claude/projects/` (Claude Code), `~/.codex/sessions/` (Codex), and `~/.pi/agent/sessions/` (pi)
 - First run indexes all sessions (a few seconds); subsequent runs are incremental
 - Only user and assistant messages are indexed (tool calls, thinking blocks, state snapshots skipped)
-- Results show `[claude]` or `[codex]` tags to indicate the source
+- Results show `[claude]`, `[codex]`, or `[pi]` tags to indicate the source
 - Dual-table FTS: English queries use Porter stemming, CJK queries use trigram matching
+- **Upgrading from 0.3.x**: run `--reindex` once to pull in pi sessions
 - **Upgrading from 0.2.x**: run `--reindex` once to build the CJK index

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ description: >
   "what did we discuss", "remember when we"
 metadata:
   author: arjunkmrm
-  version: "0.4.0"
+  version: "0.4.1"
   license: MIT
 ---
 
@@ -17,12 +17,18 @@ Search all past Claude Code, Codex, and pi sessions using full-text search with 
 ## Usage
 
 ```bash
-python3 ~/.claude/skills/recall/scripts/recall.py QUERY [--project PATH] [--days N] [--source claude|codex|pi] [--limit N] [--reindex]
+python3 ~/.claude/skills/recall/scripts/recall.py [QUERY] [--project PATH] [--days N] [--source claude|codex|pi] [--limit N] [--reindex]
 ```
 
 ## Examples
 
 ```bash
+# List every session in the last day (no text search)
+python3 ~/.claude/skills/recall/scripts/recall.py --days 1
+
+# List every pi session in the last week
+python3 ~/.claude/skills/recall/scripts/recall.py --days 7 --source pi
+
 # Simple keyword search
 python3 ~/.claude/skills/recall/scripts/recall.py "bufferStore"
 
@@ -94,5 +100,7 @@ If results are missing `File:` paths, run `--reindex` to backfill.
 - Only user and assistant messages are indexed (tool calls, thinking blocks, state snapshots skipped)
 - Results show `[claude]`, `[codex]`, or `[pi]` tags to indicate the source
 - Dual-table FTS: English queries use Porter stemming, CJK queries use trigram matching
+- Omit the query argument for **list mode** — every session in the window, sorted by recency, no FTS
+- Provide a query for full-text search; both modes accept `--project`, `--days`, `--source`, `--limit`
 - **Upgrading from 0.3.x**: run `--reindex` once to pull in pi sessions
 - **Upgrading from 0.2.x**: run `--reindex` once to build the CJK index

--- a/scripts/read_session.py
+++ b/scripts/read_session.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Pretty-print a Claude Code or Codex session transcript."""
+"""Pretty-print a Claude Code, Codex, or pi session transcript."""
 
 import json
 import sys
@@ -44,7 +44,23 @@ def iter_messages(path):
             if entry.get("record_type") == "state":
                 continue
 
-            if fmt == "claude":
+            if fmt == "pi":
+                # Pi: {type, id, parentId, timestamp, message: {role, content, ...}}
+                # Header is {type: "session", id, cwd, version, ...} — skip.
+                etype = entry.get("type", "")
+                if etype != "message":
+                    continue
+
+                msg = entry.get("message", {})
+                if not isinstance(msg, dict):
+                    continue
+
+                role = msg.get("role", "")
+                if role not in ("user", "assistant"):
+                    continue
+                content = msg.get("content", "")
+
+            elif fmt == "claude":
                 # Resolve role from type or role fields
                 role = entry.get("role", "")
                 if role not in ("user", "assistant"):
@@ -89,7 +105,14 @@ def iter_messages(path):
 
 
 def detect_format(path):
-    """Detect whether a session file is Claude Code or Codex format."""
+    """Detect whether a session file is Claude Code, Codex, or pi format.
+
+    Detection runs on the first non-empty parseable line and returns one of
+    "pi", "claude", or "codex". Order matters: pi headers carry both `type:
+    "session"` and `cwd`, which is the most distinctive signature; Claude
+    files have `parentUuid` or a top-level `message`; Codex files have
+    `record_type`, `instructions`, or `type: "session_meta"`.
+    """
     with open(path, "r", encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()
@@ -99,6 +122,15 @@ def detect_format(path):
                 entry = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            etype = entry.get("type", "")
+
+            # Pi v2/v3 header: {type: "session", id, cwd, version, ...}.
+            # Disambiguates from any "session"-typed entries elsewhere by
+            # requiring cwd or version on the same line (only present on the
+            # header).
+            if etype == "session" and ("cwd" in entry or "version" in entry):
+                return "pi"
+
             if entry.get("record_type") == "state":
                 return "codex"
             if "parentUuid" in entry or "message" in entry:
@@ -113,7 +145,7 @@ def detect_format(path):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description="Pretty-print a Claude Code or Codex session transcript")
+    parser = argparse.ArgumentParser(description="Pretty-print a Claude Code, Codex, or pi session transcript")
     parser.add_argument("path", help="Path to a session .jsonl file")
     parser.add_argument("--pretty", action="store_true", help="Human-readable output instead of JSON")
     args = parser.parse_args()

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -577,6 +577,40 @@ def sanitize_fts_query(query):
     return ''.join(parts)
 
 
+def list_sessions(conn, project=None, days=None, source=None, limit=10):
+    """List sessions in the time window without text matching.
+
+    Used when no query string is supplied. Bypasses FTS entirely — the
+    sessions table has all we need (source, project, slug, timestamp).
+    Sorted by recency. Returns rows in the same shape as search() so
+    main()'s rendering loop is unchanged: empty excerpt, rank=0.
+    """
+    conds = []
+    params = []
+    if project:
+        conds.append("project LIKE ? || '%'")
+        params.append(project)
+    if days:
+        cutoff = int((time.time() - days * 86400) * 1000)
+        conds.append("timestamp >= ?")
+        params.append(cutoff)
+    if source:
+        conds.append("source = ?")
+        params.append(source)
+
+    where = ("WHERE " + " AND ".join(conds)) if conds else ""
+    sql = (
+        "SELECT session_id, source, file_path, project, slug, timestamp "
+        f"FROM sessions {where} ORDER BY timestamp DESC LIMIT ?"
+    )
+    params.append(limit)
+
+    return [
+        (sid, src, fp, proj, slug, ts, "", 0.0)
+        for sid, src, fp, proj, slug, ts in conn.execute(sql, params).fetchall()
+    ]
+
+
 def search(conn, query, project=None, days=None, source=None, limit=10):
     """Search indexed sessions. Uses trigram table for CJK queries, porter table otherwise."""
     # Pick the right FTS table based on query content
@@ -700,7 +734,7 @@ def format_timestamp(ts_ms):
 
 def main():
     parser = argparse.ArgumentParser(description="Search past Claude Code, Codex, and pi sessions")
-    parser.add_argument("query", help="Search query (FTS5 syntax: quotes for phrases, AND/OR/NOT)")
+    parser.add_argument("query", nargs="?", help="Search query (FTS5 syntax: quotes for phrases, AND/OR/NOT). Omit to list all sessions in the time window without text matching.")
     parser.add_argument("--project", help="Filter to sessions from a specific project path (prefix match)")
     parser.add_argument("--days", type=int, help="Only sessions from last N days")
     parser.add_argument("--source", choices=["claude", "codex", "pi"], help="Filter by source (claude, codex, or pi)")
@@ -729,15 +763,22 @@ def main():
     if indexed > 0:
         print(f"Indexed {indexed} sessions in {index_time:.1f}s", file=sys.stderr)
 
-    # Search
-    results = search(conn, args.query, project=args.project, days=args.days, source=args.source, limit=args.limit)
+    # Search (with query) or list (without query)
+    if args.query:
+        results = search(conn, args.query, project=args.project, days=args.days, source=args.source, limit=args.limit)
+        empty_message = "No matching sessions found."
+        header_verb = "Found"
+    else:
+        results = list_sessions(conn, project=args.project, days=args.days, source=args.source, limit=args.limit)
+        empty_message = "No sessions in the time window."
+        header_verb = "Listed"
 
     if not results:
-        print("No matching sessions found.")
+        print(empty_message)
         conn.close()
         return
 
-    print(f"Found {len(results)} sessions (index: {total_sessions} sessions, {total_messages} messages):\n")
+    print(f"{header_verb} {len(results)} sessions (index: {total_sessions} sessions, {total_messages} messages):\n")
 
     for i, (session_id, source, file_path, project, slug, timestamp, excerpt, rank) in enumerate(results, 1):
         date = format_timestamp(timestamp)

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Search past Claude Code and Codex sessions using FTS5 full-text search."""
+"""Search past Claude Code, Codex, and pi sessions using FTS5 full-text search."""
 
 import argparse
 import json
@@ -15,9 +15,11 @@ from pathlib import Path
 
 CLAUDE_DIR = Path.home() / ".claude"
 CODEX_DIR = Path.home() / ".codex"
+PI_DIR = Path.home() / ".pi"
 DB_PATH = Path.home() / ".recall.db"
 CLAUDE_PROJECTS_DIR = CLAUDE_DIR / "projects"
 CODEX_SESSIONS_DIR = CODEX_DIR / "sessions"
+PI_SESSIONS_DIR = PI_DIR / "agent" / "sessions"
 
 
 CJK_RE = re.compile(
@@ -332,6 +334,109 @@ def parse_codex_session(path):
     return metadata, messages
 
 
+# — Pi session parser ——————————————————————————————————————————————————————
+
+def parse_pi_session(path):
+    """Parse a pi (mariozechner/pi-coding-agent) JSONL session file.
+
+    Pi sessions live in ~/.pi/agent/sessions/--<encoded-cwd>--/<ts>_<uuid>.jsonl.
+    The first line is a session header ({type: "session", id, cwd, version, ...}).
+    Subsequent lines are entries with a top-level "type" field. We index only
+    user/assistant text from {type: "message"} entries, skipping thinking,
+    toolCall, and image blocks. Other entry types (custom, custom_message,
+    session_info, model_change, thinking_level_change, compaction,
+    branch_summary, label) are skipped to mirror the Claude and Codex parsers'
+    user+assistant-only behaviour.
+
+    See https://github.com/mariozechner/pi-mono and the pi-coding-agent
+    docs/session-format.md for the full schema.
+    """
+    session_id = Path(path).stem
+    project = None
+    slug = None
+    earliest_ts = None
+    messages = []
+
+    # Filename pattern: <ISO-timestamp>_<uuid>.jsonl
+    # e.g. 2026-05-06T13-50-25-335Z_019dfd8d-da36-7552-b0d5-dfa08528cf9b.jsonl
+    uuid_match = re.search(
+        r"_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$",
+        session_id,
+    )
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                etype = entry.get("type", "")
+
+                # Session header — first line, metadata only.
+                if etype == "session":
+                    entry_id = entry.get("id", "")
+                    if entry_id:
+                        session_id = entry_id
+                    if not project:
+                        project = entry.get("cwd", "")
+                    ts_ms = parse_iso_timestamp(entry.get("timestamp"))
+                    if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
+                        earliest_ts = ts_ms
+                    continue
+
+                # Skip everything that isn't a conversational message:
+                # custom (extension state), custom_message (extension-injected),
+                # session_info (display name), model_change, thinking_level_change,
+                # compaction, branch_summary, label.
+                if etype != "message":
+                    continue
+
+                # Track earliest entry timestamp defensively in case the header
+                # is missing or files are partially written.
+                ts_ms = parse_iso_timestamp(entry.get("timestamp"))
+                if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
+                    earliest_ts = ts_ms
+
+                msg = entry.get("message", {})
+                if not isinstance(msg, dict):
+                    continue
+
+                role = msg.get("role", "")
+                # Only index user and assistant messages — skip toolResult,
+                # bashExecution, and any other non-conversational roles.
+                if role not in ("user", "assistant"):
+                    continue
+
+                text = extract_text(msg.get("content", ""))
+                if text:
+                    messages.append((role, text))
+
+    except (OSError, PermissionError) as e:
+        print(f"Warning: skipping {path}: {e}", file=sys.stderr)
+        return None
+
+    if not slug:
+        short_id = uuid_match.group(1)[:8] if uuid_match else session_id[:8]
+        ts_match = re.match(r"(\d{4}-\d{2}-\d{2})", Path(path).stem)
+        date_slug = ts_match.group(1) if ts_match else None
+        slug = f"{date_slug}-{short_id}" if date_slug else short_id
+
+    metadata = {
+        "session_id": session_id,
+        "source": "pi",
+        "file_path": path,
+        "project": project or "",
+        "slug": slug,
+        "timestamp": earliest_ts or 0,
+    }
+    return metadata, messages
+
+
 # — Indexing ———————————————————————————————————————————————————————————————
 
 def index_sessions(conn, force=False):
@@ -364,6 +469,11 @@ def index_sessions(conn, force=False):
     for fpath in glob(codex_pattern, recursive=True):
         sources.append((fpath, "codex"))
 
+    # Pi: ~/.pi/agent/sessions/**/*.jsonl
+    pi_pattern = str(PI_SESSIONS_DIR / "**" / "*.jsonl")
+    for fpath in glob(pi_pattern, recursive=True):
+        sources.append((fpath, "pi"))
+
     indexed = 0
     skipped = 0
 
@@ -390,8 +500,10 @@ def index_sessions(conn, force=False):
 
         if source == "claude":
             result = parse_claude_session(fpath)
-        else:
+        elif source == "codex":
             result = parse_codex_session(fpath)
+        else:  # pi
+            result = parse_pi_session(fpath)
 
         if result is None:
             continue
@@ -587,11 +699,11 @@ def format_timestamp(ts_ms):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Search past Claude Code and Codex sessions")
+    parser = argparse.ArgumentParser(description="Search past Claude Code, Codex, and pi sessions")
     parser.add_argument("query", help="Search query (FTS5 syntax: quotes for phrases, AND/OR/NOT)")
     parser.add_argument("--project", help="Filter to sessions from a specific project path (prefix match)")
     parser.add_argument("--days", type=int, help="Only sessions from last N days")
-    parser.add_argument("--source", choices=["claude", "codex"], help="Filter by source (claude or codex)")
+    parser.add_argument("--source", choices=["claude", "codex", "pi"], help="Filter by source (claude, codex, or pi)")
     parser.add_argument("--limit", type=int, default=10, help="Max results (default: 10)")
     parser.add_argument("--reindex", action="store_true", help="Force full rebuild of the index")
 

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Search past Claude Code and Codex sessions using FTS5 full-text search."""
+"""Search past Claude Code, Codex, and pi sessions using FTS5 full-text search."""
 
 import argparse
 import json
@@ -15,9 +15,11 @@ from pathlib import Path
 
 CLAUDE_DIR = Path.home() / ".claude"
 CODEX_DIR = Path.home() / ".codex"
+PI_DIR = Path.home() / ".pi"
 DB_PATH = Path.home() / ".recall.db"
 CLAUDE_PROJECTS_DIR = CLAUDE_DIR / "projects"
 CODEX_SESSIONS_DIR = CODEX_DIR / "sessions"
+PI_SESSIONS_DIR = PI_DIR / "agent" / "sessions"
 
 
 CJK_RE = re.compile(
@@ -332,6 +334,109 @@ def parse_codex_session(path):
     return metadata, messages
 
 
+# — Pi session parser ——————————————————————————————————————————————————————
+
+def parse_pi_session(path):
+    """Parse a pi (earendil-works/pi-coding-agent) JSONL session file.
+
+    Pi sessions live in ~/.pi/agent/sessions/--<encoded-cwd>--/<ts>_<uuid>.jsonl.
+    The first line is a session header ({type: "session", id, cwd, version, ...}).
+    Subsequent lines are entries with a top-level "type" field. We index only
+    user/assistant text from {type: "message"} entries, skipping thinking,
+    toolCall, and image blocks. Other entry types (custom, custom_message,
+    session_info, model_change, thinking_level_change, compaction,
+    branch_summary, label) are skipped to mirror the Claude and Codex parsers'
+    user+assistant-only behaviour.
+
+    See https://github.com/earendil-works/pi-mono and the pi-coding-agent
+    docs/session-format.md for the full schema.
+    """
+    session_id = Path(path).stem
+    project = None
+    slug = None
+    earliest_ts = None
+    messages = []
+
+    # Filename pattern: <ISO-timestamp>_<uuid>.jsonl
+    # e.g. 2026-05-06T13-50-25-335Z_019dfd8d-da36-7552-b0d5-dfa08528cf9b.jsonl
+    uuid_match = re.search(
+        r"_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$",
+        session_id,
+    )
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                etype = entry.get("type", "")
+
+                # Session header — first line, metadata only.
+                if etype == "session":
+                    entry_id = entry.get("id", "")
+                    if entry_id:
+                        session_id = entry_id
+                    if not project:
+                        project = entry.get("cwd", "")
+                    ts_ms = parse_iso_timestamp(entry.get("timestamp"))
+                    if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
+                        earliest_ts = ts_ms
+                    continue
+
+                # Skip everything that isn't a conversational message:
+                # custom (extension state), custom_message (extension-injected),
+                # session_info (display name), model_change, thinking_level_change,
+                # compaction, branch_summary, label.
+                if etype != "message":
+                    continue
+
+                # Track earliest entry timestamp defensively in case the header
+                # is missing or files are partially written.
+                ts_ms = parse_iso_timestamp(entry.get("timestamp"))
+                if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
+                    earliest_ts = ts_ms
+
+                msg = entry.get("message", {})
+                if not isinstance(msg, dict):
+                    continue
+
+                role = msg.get("role", "")
+                # Only index user and assistant messages — skip toolResult,
+                # bashExecution, and any other non-conversational roles.
+                if role not in ("user", "assistant"):
+                    continue
+
+                text = extract_text(msg.get("content", ""))
+                if text:
+                    messages.append((role, text))
+
+    except (OSError, PermissionError) as e:
+        print(f"Warning: skipping {path}: {e}", file=sys.stderr)
+        return None
+
+    if not slug:
+        short_id = uuid_match.group(1)[:8] if uuid_match else session_id[:8]
+        ts_match = re.match(r"(\d{4}-\d{2}-\d{2})", Path(path).stem)
+        date_slug = ts_match.group(1) if ts_match else None
+        slug = f"{date_slug}-{short_id}" if date_slug else short_id
+
+    metadata = {
+        "session_id": session_id,
+        "source": "pi",
+        "file_path": path,
+        "project": project or "",
+        "slug": slug,
+        "timestamp": earliest_ts or 0,
+    }
+    return metadata, messages
+
+
 # — Indexing ———————————————————————————————————————————————————————————————
 
 def index_sessions(conn, force=False):
@@ -364,6 +469,11 @@ def index_sessions(conn, force=False):
     for fpath in glob(codex_pattern, recursive=True):
         sources.append((fpath, "codex"))
 
+    # Pi: ~/.pi/agent/sessions/**/*.jsonl
+    pi_pattern = str(PI_SESSIONS_DIR / "**" / "*.jsonl")
+    for fpath in glob(pi_pattern, recursive=True):
+        sources.append((fpath, "pi"))
+
     indexed = 0
     skipped = 0
 
@@ -390,8 +500,10 @@ def index_sessions(conn, force=False):
 
         if source == "claude":
             result = parse_claude_session(fpath)
-        else:
+        elif source == "codex":
             result = parse_codex_session(fpath)
+        else:  # pi
+            result = parse_pi_session(fpath)
 
         if result is None:
             continue
@@ -587,11 +699,11 @@ def format_timestamp(ts_ms):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Search past Claude Code and Codex sessions")
+    parser = argparse.ArgumentParser(description="Search past Claude Code, Codex, and pi sessions")
     parser.add_argument("query", help="Search query (FTS5 syntax: quotes for phrases, AND/OR/NOT)")
     parser.add_argument("--project", help="Filter to sessions from a specific project path (prefix match)")
     parser.add_argument("--days", type=int, help="Only sessions from last N days")
-    parser.add_argument("--source", choices=["claude", "codex"], help="Filter by source (claude or codex)")
+    parser.add_argument("--source", choices=["claude", "codex", "pi"], help="Filter by source (claude, codex, or pi)")
     parser.add_argument("--limit", type=int, default=10, help="Max results (default: 10)")
     parser.add_argument("--reindex", action="store_true", help="Force full rebuild of the index")
 

--- a/tests/test_pi_parser.py
+++ b/tests/test_pi_parser.py
@@ -1,0 +1,527 @@
+"""Tests for parse_pi_session and pi detection in read_session.
+
+Pi session format (earendil-works/pi-mono, was badlogic/pi-mono):
+  - Header line: {"type": "session", "id": "...", "cwd": "...", "version": 3, ...}
+  - Subsequent lines: {"type": "message", "id": ..., "parentId": ..., "timestamp": ...,
+                       "message": {"role": "user|assistant|...", "content": ...}}
+  - Other top-level types we skip: custom, custom_message, session_info,
+    model_change, thinking_level_change, compaction, branch_summary, label.
+  - Non-conversational roles we skip: toolResult, bashExecution.
+
+Fixtures are generated as strings inside tmpdir — no fixture files committed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Make scripts/ importable as a module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import recall  # noqa: E402
+import read_session  # noqa: E402
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def write_jsonl(tmpdir: Path, name: str, entries: list[dict]) -> str:
+    """Write a list of entries as JSONL into tmpdir and return the path."""
+    path = tmpdir / name
+    with path.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry))
+            f.write("\n")
+    return str(path)
+
+
+# A representative pi v3 session: header + user (string content) + assistant
+# (mixed text/thinking/toolCall blocks) + toolResult + bashExecution +
+# custom + custom_message + session_info + model_change + thinking_level_change.
+# The parser should keep only the user text and the assistant text block.
+PI_V3_SAMPLE = [
+    {
+        "type": "session",
+        "version": 3,
+        "id": "019dfd8d-da36-7552-b0d5-dfa08528cf9b",
+        "timestamp": "2026-05-06T13:50:25.335Z",
+        "cwd": "/Users/alice/Vaults/blog",
+    },
+    {
+        "type": "message",
+        "id": "u1",
+        "parentId": None,
+        "timestamp": "2026-05-06T13:52:11.384Z",
+        "message": {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Let's do a spring cleaning."},
+            ],
+            "timestamp": 1778075531338,
+        },
+    },
+    {
+        "type": "message",
+        "id": "a1",
+        "parentId": "u1",
+        "timestamp": "2026-05-06T13:52:12.000Z",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "I should reason about this."},
+                {"type": "text", "text": "I will help you clean up."},
+                {"type": "toolCall", "id": "t1", "name": "bash", "arguments": {"cmd": "ls"}},
+            ],
+            "api": "anthropic",
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-5",
+            "usage": {"input": 1, "output": 1},
+            "stopReason": "toolUse",
+        },
+    },
+    {
+        "type": "message",
+        "id": "tr1",
+        "parentId": "a1",
+        "timestamp": "2026-05-06T13:52:13.000Z",
+        "message": {
+            "role": "toolResult",
+            "toolCallId": "t1",
+            "toolName": "bash",
+            "content": [{"type": "text", "text": "file1\nfile2"}],
+            "isError": False,
+        },
+    },
+    {
+        "type": "message",
+        "id": "be1",
+        "parentId": "tr1",
+        "timestamp": "2026-05-06T13:52:14.000Z",
+        "message": {
+            "role": "bashExecution",
+            "command": "ls -la",
+            "output": "total 0",
+            "exitCode": 0,
+            "cancelled": False,
+            "truncated": False,
+        },
+    },
+    {
+        "type": "custom",
+        "id": "c1",
+        "parentId": "be1",
+        "timestamp": "2026-05-06T13:52:15.000Z",
+        "customType": "my-extension",
+        "data": {"count": 42},
+    },
+    {
+        "type": "custom_message",
+        "id": "cm1",
+        "parentId": "c1",
+        "timestamp": "2026-05-06T13:52:16.000Z",
+        "customType": "my-extension",
+        "content": "extension-injected note",
+        "display": True,
+    },
+    {
+        "type": "session_info",
+        "id": "si1",
+        "parentId": "cm1",
+        "timestamp": "2026-05-06T13:52:17.000Z",
+        "name": "spring cleaning",
+    },
+    {
+        "type": "model_change",
+        "id": "mc1",
+        "parentId": "si1",
+        "timestamp": "2026-05-06T13:52:18.000Z",
+        "provider": "openai",
+        "modelId": "gpt-4o",
+    },
+    {
+        "type": "thinking_level_change",
+        "id": "tl1",
+        "parentId": "mc1",
+        "timestamp": "2026-05-06T13:52:19.000Z",
+        "thinkingLevel": "high",
+    },
+    {
+        "type": "message",
+        "id": "u2",
+        "parentId": "tl1",
+        "timestamp": "2026-05-06T13:52:20.000Z",
+        "message": {
+            "role": "user",
+            "content": "second user turn — plain string content",
+        },
+    },
+]
+
+
+# ── parse_pi_session ─────────────────────────────────────────────────────────
+
+
+class TestParsePiSession(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="recall-test-"))
+
+    def _write(self, name: str, entries: list[dict]) -> str:
+        return write_jsonl(self.tmpdir, name, entries)
+
+    def test_header_metadata(self):
+        """Header gives session_id, cwd→project, earliest timestamp."""
+        path = self._write(
+            "2026-05-06T13-50-25-335Z_019dfd8d-da36-7552-b0d5-dfa08528cf9b.jsonl",
+            [PI_V3_SAMPLE[0]],
+        )
+        metadata, messages = recall.parse_pi_session(path)
+        self.assertEqual(metadata["session_id"], "019dfd8d-da36-7552-b0d5-dfa08528cf9b")
+        self.assertEqual(metadata["source"], "pi")
+        self.assertEqual(metadata["project"], "/Users/alice/Vaults/blog")
+        self.assertEqual(metadata["file_path"], path)
+        self.assertGreater(metadata["timestamp"], 0)
+        self.assertEqual(messages, [])
+
+    def test_extracts_user_and_assistant_text(self):
+        """User string content and assistant TextContent are both kept."""
+        path = self._write("session.jsonl", PI_V3_SAMPLE)
+        _, messages = recall.parse_pi_session(path)
+
+        roles = [m[0] for m in messages]
+        texts = [m[1] for m in messages]
+
+        self.assertEqual(roles, ["user", "assistant", "user"])
+        self.assertIn("spring cleaning", texts[0])
+        self.assertEqual(texts[1], "I will help you clean up.")
+        self.assertIn("plain string content", texts[2])
+
+    def test_skips_thinking_toolcall_image_blocks(self):
+        """Thinking, toolCall, and image blocks are dropped from assistant content."""
+        path = self._write("session.jsonl", PI_V3_SAMPLE)
+        _, messages = recall.parse_pi_session(path)
+
+        # Assistant turn had thinking + text + toolCall — only text should remain
+        assistant_texts = [t for r, t in messages if r == "assistant"]
+        self.assertEqual(len(assistant_texts), 1)
+        self.assertNotIn("reason about this", assistant_texts[0])
+        self.assertNotIn("toolCall", assistant_texts[0])
+        self.assertNotIn("bash", assistant_texts[0])
+        self.assertEqual(assistant_texts[0], "I will help you clean up.")
+
+    def test_skips_toolresult_and_bashexecution(self):
+        """toolResult and bashExecution roles produce no indexed messages."""
+        path = self._write("session.jsonl", PI_V3_SAMPLE)
+        _, messages = recall.parse_pi_session(path)
+
+        roles = [m[0] for m in messages]
+        self.assertNotIn("toolResult", roles)
+        self.assertNotIn("bashExecution", roles)
+
+    def test_skips_non_message_top_level_types(self):
+        """custom, custom_message, session_info, model_change, thinking_level_change skipped."""
+        path = self._write("session.jsonl", PI_V3_SAMPLE)
+        _, messages = recall.parse_pi_session(path)
+
+        joined = "\n".join(t for _, t in messages)
+        self.assertNotIn("extension-injected note", joined)
+        self.assertNotIn("spring cleaning", joined.split("\n")[1] if "\n" in joined else "")
+        # We accept "spring cleaning" appearing in the user turn (that's the text).
+        # session_info.name is also "spring cleaning" — but it must not be a separate message.
+        # Total messages should be 3 (user, assistant, user), not more.
+        self.assertEqual(len(messages), 3)
+
+    def test_compaction_branch_summary_label_skipped(self):
+        """compaction, branch_summary, label entry types are skipped."""
+        entries = [PI_V3_SAMPLE[0]] + [
+            {
+                "type": "compaction",
+                "id": "comp1",
+                "parentId": None,
+                "timestamp": "2026-05-06T14:00:00.000Z",
+                "summary": "earlier turns summarized here",
+                "firstKeptEntryId": "x",
+                "tokensBefore": 1000,
+            },
+            {
+                "type": "branch_summary",
+                "id": "bs1",
+                "parentId": None,
+                "timestamp": "2026-05-06T14:01:00.000Z",
+                "fromId": "y",
+                "summary": "abandoned branch summary",
+            },
+            {
+                "type": "label",
+                "id": "lb1",
+                "parentId": None,
+                "timestamp": "2026-05-06T14:02:00.000Z",
+                "targetId": "u1",
+                "label": "checkpoint-1",
+            },
+        ]
+        path = self._write("session.jsonl", entries)
+        _, messages = recall.parse_pi_session(path)
+        self.assertEqual(messages, [])
+
+    def test_slug_includes_date_and_short_id(self):
+        """Slug derived from filename: YYYY-MM-DD-<uuid8>."""
+        name = "2026-05-06T13-50-25-335Z_019dfd8d-da36-7552-b0d5-dfa08528cf9b.jsonl"
+        path = self._write(name, [PI_V3_SAMPLE[0]])
+        metadata, _ = recall.parse_pi_session(path)
+        self.assertEqual(metadata["slug"], "2026-05-06-019dfd8d")
+
+    def test_slug_fallback_when_filename_unusual(self):
+        """Filename without the expected pattern: slug falls back to a session-id prefix."""
+        path = self._write("oddname.jsonl", [PI_V3_SAMPLE[0]])
+        metadata, _ = recall.parse_pi_session(path)
+        # Either short_id or session_id prefix — both are acceptable; just non-empty.
+        self.assertTrue(metadata["slug"])
+
+    def test_malformed_json_line_is_skipped(self):
+        """A malformed line in the middle of the file does not break parsing."""
+        path = self.tmpdir / "session.jsonl"
+        with path.open("w", encoding="utf-8") as f:
+            f.write(json.dumps(PI_V3_SAMPLE[0]) + "\n")
+            f.write("this is not json\n")
+            f.write(json.dumps(PI_V3_SAMPLE[1]) + "\n")  # user message
+        _, messages = recall.parse_pi_session(str(path))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0][0], "user")
+
+    def test_empty_lines_are_ignored(self):
+        """Blank lines do not affect parsing."""
+        path = self.tmpdir / "session.jsonl"
+        with path.open("w", encoding="utf-8") as f:
+            f.write("\n")
+            f.write(json.dumps(PI_V3_SAMPLE[0]) + "\n")
+            f.write("\n\n")
+            f.write(json.dumps(PI_V3_SAMPLE[1]) + "\n")
+            f.write("\n")
+        _, messages = recall.parse_pi_session(str(path))
+        self.assertEqual(len(messages), 1)
+
+    def test_string_content_user_message(self):
+        """User message with content as a plain string (not array)."""
+        entries = [
+            PI_V3_SAMPLE[0],
+            {
+                "type": "message",
+                "id": "u1",
+                "parentId": None,
+                "timestamp": "2026-05-06T13:52:11.000Z",
+                "message": {"role": "user", "content": "hello world"},
+            },
+        ]
+        path = self._write("session.jsonl", entries)
+        _, messages = recall.parse_pi_session(path)
+        self.assertEqual(messages, [("user", "hello world")])
+
+    def test_returns_none_on_unreadable_file(self):
+        """Permission errors yield None (warning to stderr), not an exception."""
+        path = self.tmpdir / "noperm.jsonl"
+        path.write_text(json.dumps(PI_V3_SAMPLE[0]) + "\n")
+        os.chmod(str(path), 0o000)
+        try:
+            result = recall.parse_pi_session(str(path))
+            # On some systems root can still read; accept either outcome,
+            # but if we did get a result it must be well-formed.
+            if result is not None:
+                self.assertEqual(result[0]["source"], "pi")
+        finally:
+            os.chmod(str(path), 0o600)
+
+
+# ── detect_format (read_session) ─────────────────────────────────────────────
+
+
+class TestDetectFormat(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="recall-test-"))
+
+    def _write(self, name: str, entries: list[dict]) -> str:
+        return write_jsonl(self.tmpdir, name, entries)
+
+    def test_detects_pi_from_session_header(self):
+        path = self._write("pi.jsonl", [PI_V3_SAMPLE[0]])
+        self.assertEqual(read_session.detect_format(path), "pi")
+
+    def test_detects_pi_with_version_but_no_cwd(self):
+        """Pi headers must have at least one of cwd/version."""
+        entries = [{"type": "session", "version": 3, "id": "x", "timestamp": "2026-01-01T00:00:00Z"}]
+        path = self._write("pi.jsonl", entries)
+        self.assertEqual(read_session.detect_format(path), "pi")
+
+    def test_does_not_misclassify_session_typed_entries_without_cwd_or_version(self):
+        """An entry that happens to be type='session' but lacks cwd/version is not pi."""
+        entries = [{"type": "session", "id": "x"}]  # no cwd, no version
+        path = self._write("ambig.jsonl", entries)
+        self.assertNotEqual(read_session.detect_format(path), "pi")
+
+    def test_detects_claude_from_parentuuid(self):
+        entries = [
+            {
+                "parentUuid": None,
+                "type": "user",
+                "uuid": "u1",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "message": {"role": "user", "content": "hi"},
+            }
+        ]
+        path = self._write("claude.jsonl", entries)
+        self.assertEqual(read_session.detect_format(path), "claude")
+
+    def test_detects_codex_modern_session_meta(self):
+        entries = [
+            {
+                "timestamp": "2026-01-01T00:00:00Z",
+                "type": "session_meta",
+                "payload": {"id": "x", "cwd": "/tmp"},
+            }
+        ]
+        path = self._write("codex.jsonl", entries)
+        self.assertEqual(read_session.detect_format(path), "codex")
+
+    def test_detects_codex_legacy_state_record(self):
+        entries = [{"record_type": "state", "id": "x"}]
+        path = self._write("codex-legacy.jsonl", entries)
+        self.assertEqual(read_session.detect_format(path), "codex")
+
+
+# ── read_session.iter_messages on pi ─────────────────────────────────────────
+
+
+class TestIterMessagesPi(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="recall-test-"))
+
+    def test_iter_pi_yields_user_and_assistant_only(self):
+        path = write_jsonl(self.tmpdir, "session.jsonl", PI_V3_SAMPLE)
+        out = list(read_session.iter_messages(path))
+        roles = [r for r, _ in out]
+        self.assertEqual(roles, ["user", "assistant", "user"])
+        # Assistant text is the plain TextContent only, not thinking/toolCall
+        self.assertEqual(out[1][1], "I will help you clean up.")
+
+
+# ── list_sessions ────────────────────────────────────────────────────────────
+
+
+class TestListSessions(unittest.TestCase):
+    def setUp(self):
+        import sqlite3
+        import time
+
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="recall-test-"))
+        self.db_path = self.tmpdir / "recall.db"
+        self.conn = sqlite3.connect(str(self.db_path))
+        recall.create_schema(self.conn)
+        recall.migrate_schema(self.conn)
+
+        # Seed with three sessions across three sources, recent first.
+        now_ms = int(time.time() * 1000)
+        day = 86_400_000
+        rows = [
+            ("pi-recent", "pi", "/p/recent.jsonl", "/Users/alice/proj-a", "slug-pi-recent", now_ms),
+            ("claude-older", "claude", "/c/older.jsonl", "/Users/alice/proj-b", "slug-claude-older", now_ms - 3 * day),
+            ("codex-oldest", "codex", "/x/oldest.jsonl", "/Users/alice/proj-a", "slug-codex-oldest", now_ms - 30 * day),
+        ]
+        for sid, src, fp, proj, slug, ts in rows:
+            self.conn.execute(
+                "INSERT INTO sessions (session_id, source, file_path, project, slug, timestamp, mtime) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (sid, src, fp, proj, slug, ts, 0.0),
+            )
+        self.conn.commit()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_returns_all_sessions_sorted_by_recency(self):
+        rows = recall.list_sessions(self.conn, limit=10)
+        slugs = [r[4] for r in rows]
+        self.assertEqual(slugs, ["slug-pi-recent", "slug-claude-older", "slug-codex-oldest"])
+
+    def test_filters_by_source(self):
+        rows = recall.list_sessions(self.conn, source="pi", limit=10)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][1], "pi")
+
+    def test_filters_by_days(self):
+        """--days 1 keeps the recent pi session, drops the older two."""
+        rows = recall.list_sessions(self.conn, days=1, limit=10)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][4], "slug-pi-recent")
+
+    def test_filters_by_project_prefix(self):
+        """--project filters by prefix match against the stored project path."""
+        rows = recall.list_sessions(self.conn, project="/Users/alice/proj-a", limit=10)
+        self.assertEqual(sorted(r[4] for r in rows), ["slug-codex-oldest", "slug-pi-recent"])
+
+    def test_combines_filters(self):
+        """Multiple filters AND together."""
+        rows = recall.list_sessions(
+            self.conn, source="pi", project="/Users/alice/proj-a", days=1, limit=10
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][4], "slug-pi-recent")
+
+    def test_respects_limit(self):
+        rows = recall.list_sessions(self.conn, limit=2)
+        self.assertEqual(len(rows), 2)
+
+    def test_empty_db(self):
+        """List mode on an empty sessions table returns []."""
+        self.conn.execute("DELETE FROM sessions")
+        self.conn.commit()
+        self.assertEqual(recall.list_sessions(self.conn, limit=10), [])
+
+    def test_row_shape_matches_search_results(self):
+        """Returned tuples have the same arity as search() rows (8 fields)."""
+        rows = recall.list_sessions(self.conn, limit=1)
+        self.assertEqual(len(rows[0]), 8)
+        # Last two columns are excerpt and rank — empty / zero for list mode.
+        self.assertEqual(rows[0][6], "")
+        self.assertEqual(rows[0][7], 0.0)
+
+
+# ── Integration: round-trip a real pi session through the parser ─────────────
+
+
+class TestRealPiSession(unittest.TestCase):
+    """End-to-end: if the host has any pi sessions on disk, parse one and assert
+    the parser produces well-formed output. Skipped on machines without pi.
+    """
+
+    def test_parse_any_real_pi_session(self):
+        pi_dir = Path.home() / ".pi" / "agent" / "sessions"
+        if not pi_dir.is_dir():
+            self.skipTest("no pi sessions on this host")
+
+        files = sorted(pi_dir.glob("**/*.jsonl"))
+        if not files:
+            self.skipTest("no pi session files on this host")
+
+        # Pick the smallest non-empty file to keep the test fast.
+        smallest = min((f for f in files if f.stat().st_size > 100), key=lambda f: f.stat().st_size, default=None)
+        if smallest is None:
+            self.skipTest("no usable pi session files on this host")
+
+        result = recall.parse_pi_session(str(smallest))
+        self.assertIsNotNone(result)
+        metadata, messages = result
+        self.assertEqual(metadata["source"], "pi")
+        self.assertTrue(metadata["session_id"])
+        self.assertTrue(metadata["slug"])
+        self.assertGreater(metadata["timestamp"], 0)
+        # Every message must be user or assistant, with non-empty text.
+        for role, text in messages:
+            self.assertIn(role, ("user", "assistant"))
+            self.assertTrue(text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two additive features. Draft for review while I exercise the changes locally for a few more days.

## What

**1. Index pi (mariozechner/pi-coding-agent) sessions** — `~/.pi/agent/sessions/**/*.jsonl`, alongside the existing Claude and Codex globs. Same FTS5 schema, same DB. New `--source pi` filter and `[pi]` result tag. `read_session.py` auto-detects the format.

**2. Make the positional `query` optional** — when omitted, `recall` lists every session in the time window via direct SQL on the `sessions` table. Bypasses FTS entirely. Banner reads `Listed N sessions ...` (vs `Found ...`) so the caller can see which path ran. Useful when an agent / retro flow wants every session in a window rather than a search hit.

Pi format reference: <https://github.com/mariozechner/pi-mono> · session-format docs ship with the `@mariozechner/pi-coding-agent` npm package under `docs/session-format.md`.

## Diff

| | |
|---|---|
| Commits | 2 |
| Files | 5 (recall.py, read_session.py, SKILL.md, README.md, CHANGELOG.md) |
| +/− | +268 / −27 |

No schema change. No upstream API change to existing flags. Existing callers keep working unchanged; `query` is now optional but supplying it routes to the same `search()` path as before.

## Pi parser

Mirrors `parse_codex_session` shape:

- Header line `{type: "session", id, cwd, version, ...}` — extract `cwd` → project, `id` → session_id, `timestamp` → earliest_ts.
- Subsequent `{type: "message"}` entries — keep only `role ∈ {"user","assistant"}` and only TextContent blocks (skip `thinking`, `toolCall`, `image`).
- Skip every other top-level type: `custom`, `custom_message`, `session_info`, `model_change`, `thinking_level_change`, `compaction`, `branch_summary`, `label`. Skip non-conversational roles `toolResult`, `bashExecution`.
- Same user+assistant-only behaviour as the existing parsers.

## Format detection

`detect_format()` returns one of `pi | claude | codex` from the first non-empty parseable line. Pi headers are tested first because they carry the most distinctive signature (`type == "session"` with `cwd` or `version` on the same line — only present on the header).

## Verified locally

Real machine with all three agents in history:

```
$ rm -f /tmp/test.db ; python3 -c "..." # build fresh index against /tmp/test.db
Indexed 1841; total_sessions=1841, total_messages=29184
Per-source: [('claude', 1778), ('codex', 31), ('pi', 32)]

$ recall --days 7                        # list mode, mixed [claude] [codex] [pi]
$ recall --days 7 --source pi            # only pi
$ recall "buffer" --days 7 --source pi   # FTS path on pi sessions
$ read_session.py <pi-file> --pretty     # auto-detects pi, prints user/assistant turns
```

Reindex on this corpus: ~7s.

## Backward compatibility

- `recall <query> ...`: unchanged.
- `recall ... --source claude|codex`: unchanged.
- `--source pi`: new value.
- `recall ... ` (no query): new list-mode path.
- DB schema: unchanged.
- Run `--reindex` once after upgrade to pull pi sessions into the existing `~/.recall.db`.

## Why submit both as one PR

The list-mode commit lands on top of pi support and uses no pi-specific code, so the two are independent and easy to split if you'd prefer two PRs — say the word and I'll repoint commit 2 onto a separate branch. Bundled here because they ship together in the dotfiles deployment that drove this work.

## Open questions

- Pi headers in v2 sessions (auto-migrated to v3 on load by pi itself) carry the same `cwd` field, so detection works for both. Behaviour against very old (v1, linear, pre-tree) sessions hasn't been tested — none on this machine. If you have any v1 transcripts, I'd appreciate a sample for the regression test.
- Happy to add per-source reindex benchmarks to the CHANGELOG if you'd like — current 0.4.0 entry has the totals but not the per-agent split.