### PR TITLE
Serialise index updates so concurrent runs don't crash

### DIFF
--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -2,6 +2,7 @@
 """Search past Claude Code, Codex, and pi sessions using FTS5 full-text search."""
 
 import argparse
+import fcntl
 import json
 import os
 import re
@@ -9,6 +10,7 @@ import sqlite3
 import sys
 import math
 import time
+from contextlib import contextmanager
 from datetime import datetime
 from glob import glob
 from pathlib import Path
@@ -17,9 +19,46 @@ CLAUDE_DIR = Path.home() / ".claude"
 CODEX_DIR = Path.home() / ".codex"
 PI_DIR = Path.home() / ".pi"
 DB_PATH = Path.home() / ".recall.db"
+DB_LOCK_PATH = Path.home() / ".recall.db.lock"
 CLAUDE_PROJECTS_DIR = CLAUDE_DIR / "projects"
 CODEX_SESSIONS_DIR = CODEX_DIR / "sessions"
 PI_SESSIONS_DIR = PI_DIR / "agent" / "sessions"
+
+
+# How long a run waits for another run to finish indexing before giving up and
+# searching the index as it stands. Waiting forever would turn one stalled
+# process into a hang in every other session.
+LOCK_WAIT_SECONDS = 20
+
+
+@contextmanager
+def index_lock():
+    """Hold an exclusive lock for the duration of an index update.
+
+    Indexing is one write transaction spanning every file it parses, so a
+    second run that starts during a long index waits on SQLite's busy timeout
+    and then dies with "database is locked". Waiting on a file lock instead
+    means the second run simply skips indexing and searches.
+
+    Yields True when the lock was taken, False when the wait ran out.
+    """
+    with open(DB_LOCK_PATH, "a", encoding="utf-8") as lock_file:
+        deadline = time.monotonic() + LOCK_WAIT_SECONDS
+        while True:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    print(
+                        "Another process is indexing; searching the current index.",
+                        file=sys.stderr,
+                    )
+                    yield False
+                    return
+                time.sleep(0.1)
+        # Closing the file releases the lock on every path, exceptions included.
+        yield True
 
 
 CJK_RE = re.compile(
@@ -540,11 +579,15 @@ def index_sessions(conn, force=False):
         conn.execute("INSERT INTO messages_cjk(messages_cjk, rank) VALUES('automerge', 4)")
         conn.commit()
 
-    # Get totals
-    total_sessions = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
-    total_messages = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    return indexed, skipped, *index_totals(conn)
 
-    return indexed, skipped, total_sessions, total_messages
+
+def index_totals(conn):
+    """How many sessions and messages the index currently holds."""
+    return (
+        conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0],
+        conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0],
+    )
 
 
 # — Search —————————————————————————————————————————————————————————————————
@@ -755,9 +798,14 @@ def main():
     create_schema(conn)
     migrate_schema(conn)
 
-    # Index
+    # Index — one run at a time, so concurrent runs queue instead of colliding
     t0 = time.time()
-    indexed, skipped, total_sessions, total_messages = index_sessions(conn, force=args.reindex)
+    with index_lock() as have_lock:
+        if have_lock:
+            indexed, skipped, total_sessions, total_messages = index_sessions(conn, force=args.reindex)
+        else:
+            indexed = 0
+            total_sessions, total_messages = index_totals(conn)
     index_time = time.time() - t0
 
     if indexed > 0:

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -2,7 +2,6 @@
 """Search past Claude Code, Codex, and pi sessions using FTS5 full-text search."""
 
 import argparse
-import fcntl
 import json
 import os
 import re
@@ -14,6 +13,11 @@ from contextlib import contextmanager
 from datetime import datetime
 from glob import glob
 from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # Windows has no flock; run unlocked as before
+    fcntl = None
 
 CLAUDE_DIR = Path.home() / ".claude"
 CODEX_DIR = Path.home() / ".codex"
@@ -41,7 +45,12 @@ def index_lock():
     means the second run simply skips indexing and searches.
 
     Yields True when the lock was taken, False when the wait ran out.
+    On platforms without fcntl (Windows), yields True without locking,
+    which is the pre-lock behavior.
     """
+    if fcntl is None:
+        yield True
+        return
     with open(DB_LOCK_PATH, "a", encoding="utf-8") as lock_file:
         deadline = time.monotonic() + LOCK_WAIT_SECONDS
         while True:

--- a/tests/test_index_lock.py
+++ b/tests/test_index_lock.py
@@ -1,0 +1,103 @@
+"""Tests for index_lock.
+
+Indexing is a single write transaction spanning every file it parses. Without
+a lock, a second run started during a long index waits out SQLite's busy
+timeout and then dies with "database is locked".
+
+Fixtures are generated inside tmpdir — no fixture files committed.
+"""
+from __future__ import annotations
+
+import fcntl
+import io
+import os
+import sys
+import tempfile
+import time
+import unittest
+from contextlib import contextmanager, redirect_stderr
+from pathlib import Path
+
+# Make scripts/ importable as a module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import recall  # noqa: E402
+
+
+@contextmanager
+def lock_held_elsewhere(lock_path):
+    """Hold the lock the way another run would.
+
+    flock belongs to the open file description rather than the process, so a
+    second handle on the same path contends with the first even from here.
+    """
+    Path(lock_path).touch()
+    handle = open(lock_path, "a", encoding="utf-8")
+    fcntl.flock(handle, fcntl.LOCK_EX)
+    try:
+        yield
+    finally:
+        handle.close()
+
+
+class IndexLock(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.lock_path = str(Path(tmp.name) / "recall.db.lock")
+
+        for name, value in (("DB_LOCK_PATH", Path(self.lock_path)),
+                            ("LOCK_WAIT_SECONDS", 0.3)):
+            self.addCleanup(setattr, recall, name, getattr(recall, name))
+            setattr(recall, name, value)
+
+    def test_an_uncontended_run_takes_the_lock(self):
+        with recall.index_lock() as have_lock:
+            self.assertTrue(have_lock)
+
+    def test_the_lock_is_released_afterwards(self):
+        with recall.index_lock():
+            pass
+        with recall.index_lock() as have_lock:
+            self.assertTrue(have_lock)
+
+    def test_the_lock_is_released_even_when_the_body_raises(self):
+        with self.assertRaises(ValueError):
+            with recall.index_lock():
+                raise ValueError("indexing blew up")
+        with recall.index_lock() as have_lock:
+            self.assertTrue(have_lock)
+
+    def test_a_second_run_does_not_get_the_lock(self):
+        with lock_held_elsewhere(self.lock_path):
+            with redirect_stderr(io.StringIO()):
+                with recall.index_lock() as have_lock:
+                    self.assertFalse(have_lock)
+
+    def test_a_second_run_gives_up_rather_than_hanging(self):
+        with lock_held_elsewhere(self.lock_path):
+            started = time.monotonic()
+            with redirect_stderr(io.StringIO()):
+                with recall.index_lock():
+                    pass
+            waited = time.monotonic() - started
+        self.assertGreaterEqual(waited, recall.LOCK_WAIT_SECONDS)
+        self.assertLess(waited, recall.LOCK_WAIT_SECONDS + 5)
+
+    def test_giving_up_says_so(self):
+        stderr = io.StringIO()
+        with lock_held_elsewhere(self.lock_path):
+            with redirect_stderr(stderr):
+                with recall.index_lock():
+                    pass
+        self.assertIn("Another process is indexing", stderr.getvalue())
+
+    def test_the_lock_file_is_created_if_absent(self):
+        self.assertFalse(os.path.exists(self.lock_path))
+        with recall.index_lock() as have_lock:
+            self.assertTrue(have_lock)
+        self.assertTrue(os.path.exists(self.lock_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_index_lock.py
+++ b/tests/test_index_lock.py
@@ -92,6 +92,14 @@ class IndexLock(unittest.TestCase):
                     pass
         self.assertIn("Another process is indexing", stderr.getvalue())
 
+    def test_runs_unlocked_where_fcntl_is_unavailable(self):
+        # Windows: no flock, so indexing proceeds as it did before the lock.
+        self.addCleanup(setattr, recall, "fcntl", recall.fcntl)
+        recall.fcntl = None
+        with recall.index_lock() as have_lock:
+            self.assertTrue(have_lock)
+        self.assertFalse(os.path.exists(self.lock_path))
+
     def test_the_lock_file_is_created_if_absent(self):
         self.assertFalse(os.path.exists(self.lock_path))
         with recall.index_lock() as have_lock:


### PR DESCRIPTION
## The problem

`index_sessions` opens a write transaction at

```python
conn.execute("INSERT INTO messages(messages, rank) VALUES('automerge', 0)")
```

and holds it until the single `conn.commit()` after every file has been parsed. One index run is therefore one long write transaction. A second `recall` started during that window waits out SQLite's default 5 s busy timeout and then dies, because `main()` doesn't guard `index_sessions`:

```
Traceback (most recent call last):
  ...
  File "scripts/recall.py", line 481, in index_sessions
    conn.execute("INSERT INTO messages(messages, rank) VALUES('automerge', 0)")
sqlite3.OperationalError: database is locked
```

This is easy to hit in normal use — two agents, or an agent and a shell, searching while the index is cold. The first run on a large corpus takes long enough for the second to land inside it.

I reproduced it on a 372 MB / 4000 file corpus by starting the second run 2 s into the first:

```
A exit=0
B exit=1   sqlite3.OperationalError: database is locked
```

## The change

Take an exclusive `flock` on `~/.recall.db.lock` around the index phase, so a second run waits for the first rather than racing it.

If the wait passes `LOCK_WAIT_SECONDS` (20), it gives up, says so on stderr, and searches the index as it stands. A slow index degrades to a slightly stale search rather than a hang — I deliberately avoided a bare blocking `flock`, since one stalled process would then hang every other invocation with no output.

Same corpus, same timing, with the change:

```
A exit=0
B exit=0   "Another process is indexing; searching the current index."
```

The two `COUNT(*)` queries move into `index_totals()` so the skip path can still print the header line.

## Notes

- POSIX only, via `fcntl`. The script already assumes a POSIX layout for session paths, so I didn't add a fallback; happy to guard the import if you'd rather it degrade on Windows.
- `tests/test_index_lock.py` covers taking the lock, releasing it on the error path, contention, the timeout, and the message. `python3 -m unittest discover tests -v` — 35 tests, all pass.
- No schema change, no reindex needed.