### PR TITLE
Add Grok CLI session support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- Add Grok CLI session support — indexes `~/.grok/sessions/**/chat_history.jsonl`
+  alongside Claude Code, Codex and pi
+- New `--source grok` filter; results tagged `[grok]`
+- Grok sessions are one directory each, with the cwd percent-encoded into the
+  parent directory name and an optional `summary.json` supplying the title,
+  cwd and creation time. Transcript entries carry no timestamps of their own.
+- Entries marked `synthetic_reason` are harness context rather than real turns,
+  and are skipped, as are `<user_info>`, `<system-reminder>` and `<git_status>`
+  blocks
+- `read_session.py` reads Grok transcripts, detected by path
+
 ## 0.4.1
 
 - Make the positional `query` argument optional. When omitted, list every

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # recall
 
-Ever lost a conversation session with Claude Code, Codex, or pi and wish you could resume it? This skill lets your agents search across all your past conversations with full-text search. Builds a SQLite FTS5 index over `~/.claude/projects/`, `~/.codex/sessions/`, and `~/.pi/agent/sessions/` with BM25 ranking, Porter stemming, CJK support, and incremental updates.
+Ever lost a conversation session with Claude Code, Codex, pi or Grok and wish you could resume it? This skill lets your agents search across all your past conversations with full-text search. Builds a SQLite FTS5 index over `~/.claude/projects/`, `~/.codex/sessions/`, `~/.pi/agent/sessions/`, and `~/.grok/sessions/` with BM25 ranking, Porter stemming, CJK support, and incremental updates.
 
 ## Install
 
@@ -8,7 +8,7 @@ Ever lost a conversation session with Claude Code, Codex, or pi and wish you cou
 npx skills add arjunkmrm/recall
 ```
 
-Then use `/recall` in Claude Code (or Codex, or pi) or ask "find a past session where we talked about foo" (you might need to restart your agent).
+Then use `/recall` in Claude Code (or Codex, pi, or Grok) or ask "find a past session where we talked about foo" (you might need to restart your agent).
 
 ## How it works
 ### Index
@@ -18,7 +18,8 @@ Then use `/recall` in Claude Code (or Codex, or pi) or ask "find a past session 
                                   │
   ~/.codex/sessions/**/*.jsonl ───┼─▶ Index ──▶ ~/.recall.db (SQLite FTS5)
                                   │   [incremental - mtime-based]
-  ~/.pi/agent/sessions/**/*.jsonl ┘
+  ~/.pi/agent/sessions/**/*.jsonl │
+  ~/.grok/sessions/**/chat_history.jsonl ┘
 ```
 ### Query
 ```
@@ -43,7 +44,7 @@ Then use `/recall` in Claude Code (or Codex, or pi) or ask "find a past session 
 - CJK messages are selectively indexed into the trigram table; query routing is automatic
 - Skips tool_use, tool_result, thinking, and image blocks
 - Results ranked by BM25 with a slight recency bias (recent sessions get up to a 20% boost, decaying with a 30-day half-life)
-- Results tagged `[claude]`, `[codex]`, or `[pi]` with highlighted excerpts
+- Results tagged `[claude]`, `[codex]`, `[pi]`, or `[grok]` with highlighted excerpts
 - No dependencies — Python 3.9+ stdlib only (sqlite3, json, argparse)
 
 ## Tests

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: recall
 description: >
-  Search past Claude Code, Codex, and pi sessions. Triggers: /recall, "search old conversations",
+  Search past Claude Code, Codex, pi and Grok sessions. Triggers: /recall, "search old conversations",
   "find a past session", "recall a previous conversation", "search session history",
   "what did we discuss", "remember when we"
 metadata:
@@ -10,14 +10,14 @@ metadata:
   license: MIT
 ---
 
-# /recall — Search Past Claude, Codex & pi Sessions
+# /recall — Search Past Claude, Codex, pi & Grok Sessions
 
-Search all past Claude Code, Codex, and pi sessions using full-text search with BM25 ranking.
+Search all past Claude Code, Codex, pi and Grok sessions using full-text search with BM25 ranking.
 
 ## Usage
 
 ```bash
-python3 ~/.claude/skills/recall/scripts/recall.py [QUERY] [--project PATH] [--days N] [--source claude|codex|pi] [--limit N] [--reindex]
+python3 ~/.claude/skills/recall/scripts/recall.py [QUERY] [--project PATH] [--days N] [--source claude|codex|pi|grok] [--limit N] [--reindex]
 ```
 
 ## Examples
@@ -53,6 +53,9 @@ python3 ~/.claude/skills/recall/scripts/recall.py "buffer" --source codex
 # Search only pi sessions
 python3 ~/.claude/skills/recall/scripts/recall.py "buffer" --source pi
 
+# Search only Grok sessions
+python3 ~/.claude/skills/recall/scripts/recall.py "buffer" --source grok
+
 # Force reindex
 python3 ~/.claude/skills/recall/scripts/recall.py --reindex "test"
 ```
@@ -79,6 +82,11 @@ claude --resume SESSION_ID
 cd /path/to/project
 codex resume SESSION_ID
 
+# Grok sessions [grok]
+```bash
+grok --resume SESSION_ID
+```
+
 # Pi sessions [pi]
 cd /path/to/project
 pi --session SESSION_ID         # full or partial id; pi resolves prefix matches
@@ -95,12 +103,13 @@ If results are missing `File:` paths, run `--reindex` to backfill.
 ## Notes
 
 - Index is stored at `~/.recall.db` (SQLite FTS5, auto-migrated from `~/.claude/recall.db`)
-- Indexes three sources: `~/.claude/projects/` (Claude Code), `~/.codex/sessions/` (Codex), and `~/.pi/agent/sessions/` (pi)
+- Indexes four sources: `~/.claude/projects/` (Claude Code), `~/.codex/sessions/` (Codex), `~/.pi/agent/sessions/` (pi), and `~/.grok/sessions/**/chat_history.jsonl` (Grok)
 - First run indexes all sessions (a few seconds); subsequent runs are incremental
 - Only user and assistant messages are indexed (tool calls, thinking blocks, state snapshots skipped)
-- Results show `[claude]`, `[codex]`, or `[pi]` tags to indicate the source
+- Results show `[claude]`, `[codex]`, `[pi]`, or `[grok]` tags to indicate the source
 - Dual-table FTS: English queries use Porter stemming, CJK queries use trigram matching
 - Omit the query argument for **list mode** — every session in the window, sorted by recency, no FTS
 - Provide a query for full-text search; both modes accept `--project`, `--days`, `--source`, `--limit`
 - **Upgrading from 0.3.x**: run `--reindex` once to pull in pi sessions
+- **Upgrading from 0.4.x**: run `--reindex` once to pull in Grok sessions
 - **Upgrading from 0.2.x**: run `--reindex` once to build the CJK index

--- a/scripts/read_session.py
+++ b/scripts/read_session.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-"""Pretty-print a Claude Code, Codex, or pi session transcript."""
+"""Pretty-print a Claude Code, Codex, pi, or Grok session transcript."""
 
 import json
 import sys
+from pathlib import Path
 
 TEXT_BLOCK_TYPES = {"text", "input_text", "output_text"}
 
 SKIP_MARKERS = (
     "<user_instructions>", "<environment_context>",
     "<permissions instructions>", "# AGENTS.md instructions",
+    "<user_info>", "<system-reminder>", "<git_status>",
 )
 
 
@@ -60,6 +62,20 @@ def iter_messages(path):
                     continue
                 content = msg.get("content", "")
 
+            elif fmt == "grok":
+                # Grok: top-level type and a content string. Entries carrying
+                # synthetic_reason are harness context, not real turns.
+                if entry.get("synthetic_reason"):
+                    continue
+                etype = entry.get("type", "")
+                if etype in ("user", "human"):
+                    role = "user"
+                elif etype == "assistant":
+                    role = "assistant"
+                else:
+                    continue
+                content = entry.get("content", "")
+
             elif fmt == "claude":
                 # Resolve role from type or role fields
                 role = entry.get("role", "")
@@ -105,14 +121,22 @@ def iter_messages(path):
 
 
 def detect_format(path):
-    """Detect whether a session file is Claude Code, Codex, or pi format.
+    """Detect whether a session file is Claude Code, Codex, pi, or Grok format.
 
-    Detection runs on the first non-empty parseable line and returns one of
-    "pi", "claude", or "codex". Order matters: pi headers carry both `type:
-    "session"` and `cwd`, which is the most distinctive signature; Claude
-    files have `parentUuid` or a top-level `message`; Codex files have
-    `record_type`, `instructions`, or `type: "session_meta"`.
+    Grok is settled by path, since every Grok transcript is named
+    chat_history.jsonl inside a per-session directory and its entries are too
+    plain to tell apart from the others by content alone.
+
+    Otherwise detection runs on the first non-empty parseable line. Order
+    matters: pi headers carry both `type: "session"` and `cwd`, which is the
+    most distinctive signature; Claude files have `parentUuid` or a top-level
+    `message`; Codex files have `record_type`, `instructions`, or
+    `type: "session_meta"`.
     """
+    path_obj = Path(path)
+    if path_obj.name == "chat_history.jsonl" or "/.grok/sessions/" in str(path_obj):
+        return "grok"
+
     with open(path, "r", encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()

--- a/scripts/read_session.py
+++ b/scripts/read_session.py
@@ -10,8 +10,11 @@ TEXT_BLOCK_TYPES = {"text", "input_text", "output_text"}
 SKIP_MARKERS = (
     "<user_instructions>", "<environment_context>",
     "<permissions instructions>", "# AGENTS.md instructions",
-    "<user_info>", "<system-reminder>", "<git_status>",
 )
+
+# Grok-only: these appear inside genuine Claude user turns (system-reminder
+# blocks are appended to real prompts), so they must not be in the shared list.
+GROK_SKIP_MARKERS = ("<user_info>", "<system-reminder>", "<git_status>")
 
 
 def extract_text(content):
@@ -114,7 +117,8 @@ def iter_messages(path):
                     continue
 
             text = extract_text(content)
-            if not text or any(marker in text for marker in SKIP_MARKERS):
+            markers = SKIP_MARKERS + (GROK_SKIP_MARKERS if fmt == "grok" else ())
+            if not text or any(marker in text for marker in markers):
                 continue
 
             yield role, text

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Search past Claude Code, Codex, and pi sessions using FTS5 full-text search."""
+"""Search past Claude Code, Codex, pi and Grok sessions using FTS5 full-text search."""
 
 import argparse
 import json
@@ -12,14 +12,17 @@ import time
 from datetime import datetime
 from glob import glob
 from pathlib import Path
+from urllib.parse import unquote
 
 CLAUDE_DIR = Path.home() / ".claude"
 CODEX_DIR = Path.home() / ".codex"
 PI_DIR = Path.home() / ".pi"
+GROK_DIR = Path.home() / ".grok"
 DB_PATH = Path.home() / ".recall.db"
 CLAUDE_PROJECTS_DIR = CLAUDE_DIR / "projects"
 CODEX_SESSIONS_DIR = CODEX_DIR / "sessions"
 PI_SESSIONS_DIR = PI_DIR / "agent" / "sessions"
+GROK_SESSIONS_DIR = GROK_DIR / "sessions"
 
 
 CJK_RE = re.compile(
@@ -92,6 +95,7 @@ def migrate_db_location():
 
 TEXT_BLOCK_TYPES = {"text", "input_text", "output_text"}
 CODEX_SKIP_MARKERS = ("<user_instructions>", "<environment_context>", "<permissions instructions>", "# AGENTS.md instructions")
+GROK_SKIP_MARKERS = ("<user_info>", "<system-reminder>", "<git_status>")
 
 
 def extract_text(content):
@@ -437,6 +441,91 @@ def parse_pi_session(path):
     return metadata, messages
 
 
+def parse_grok_session(path):
+    """Parse a Grok CLI chat_history.jsonl, returning (metadata, messages).
+
+    Grok sessions live in ~/.grok/sessions/<percent-encoded-cwd>/<uuid>/, one
+    directory per session, with the transcript in chat_history.jsonl. Entries
+    carry a top-level "type" and a "content" string; there are no timestamps,
+    so the session's time comes from the optional sibling summary.json, which
+    also supplies the cwd and the generated title.
+
+    Entries marked with "synthetic_reason" are harness context Grok injects
+    into the turn list rather than anything the user or the model said, so they
+    are skipped, as are the harness blocks in GROK_SKIP_MARKERS.
+    """
+    path = Path(path)
+    session_dir = path.parent
+    session_id = session_dir.name
+    project = ""
+    slug = None
+    earliest_ts = None
+    messages = []
+
+    summary_path = session_dir / "summary.json"
+    if summary_path.is_file():
+        try:
+            with open(summary_path, "r", encoding="utf-8", errors="replace") as f:
+                summary = json.load(f)
+            info = summary.get("info") or {}
+            project = info.get("cwd") or summary.get("git_root_dir") or ""
+            slug = summary.get("generated_title") or summary.get("session_summary") or None
+            earliest_ts = parse_iso_timestamp(summary.get("created_at"))
+        except (OSError, json.JSONDecodeError, TypeError):
+            pass
+
+    if not project:
+        # The parent directory is the percent-encoded absolute cwd.
+        project = unquote(session_dir.parent.name)
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if entry.get("synthetic_reason"):
+                    continue
+
+                etype = entry.get("type", "")
+                if etype in ("user", "human"):
+                    role = "user"
+                elif etype == "assistant":
+                    role = "assistant"
+                else:
+                    continue
+
+                text = extract_text(entry.get("content", ""))
+                if not text:
+                    continue
+                if any(marker in text for marker in GROK_SKIP_MARKERS):
+                    continue
+
+                messages.append((role, text))
+
+    except (OSError, PermissionError) as e:
+        print(f"Warning: skipping {path}: {e}", file=sys.stderr)
+        return None
+
+    if not slug:
+        slug = session_id[:12]
+
+    metadata = {
+        "session_id": session_id,
+        "source": "grok",
+        "file_path": str(path),
+        "project": project,
+        "slug": slug,
+        "timestamp": earliest_ts or 0,
+    }
+    return metadata, messages
+
+
 # — Indexing ———————————————————————————————————————————————————————————————
 
 def index_sessions(conn, force=False):
@@ -456,7 +545,7 @@ def index_sessions(conn, force=False):
     except sqlite3.OperationalError:
         pass
 
-    # Collect files from both sources
+    # Collect files from every source
     sources = []
 
     # Claude Code: ~/.claude/projects/**/*.jsonl
@@ -473,6 +562,11 @@ def index_sessions(conn, force=False):
     pi_pattern = str(PI_SESSIONS_DIR / "**" / "*.jsonl")
     for fpath in glob(pi_pattern, recursive=True):
         sources.append((fpath, "pi"))
+
+    # Grok: ~/.grok/sessions/**/chat_history.jsonl
+    grok_pattern = str(GROK_SESSIONS_DIR / "**" / "chat_history.jsonl")
+    for fpath in glob(grok_pattern, recursive=True):
+        sources.append((fpath, "grok"))
 
     indexed = 0
     skipped = 0
@@ -502,8 +596,10 @@ def index_sessions(conn, force=False):
             result = parse_claude_session(fpath)
         elif source == "codex":
             result = parse_codex_session(fpath)
-        else:  # pi
+        elif source == "pi":
             result = parse_pi_session(fpath)
+        else:  # grok
+            result = parse_grok_session(fpath)
 
         if result is None:
             continue
@@ -733,11 +829,11 @@ def format_timestamp(ts_ms):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Search past Claude Code, Codex, and pi sessions")
+    parser = argparse.ArgumentParser(description="Search past Claude Code, Codex, pi and Grok sessions")
     parser.add_argument("query", nargs="?", help="Search query (FTS5 syntax: quotes for phrases, AND/OR/NOT). Omit to list all sessions in the time window without text matching.")
     parser.add_argument("--project", help="Filter to sessions from a specific project path (prefix match)")
     parser.add_argument("--days", type=int, help="Only sessions from last N days")
-    parser.add_argument("--source", choices=["claude", "codex", "pi"], help="Filter by source (claude, codex, or pi)")
+    parser.add_argument("--source", choices=["claude", "codex", "pi", "grok"], help="Filter by source (claude, codex, pi, or grok)")
     parser.add_argument("--limit", type=int, default=10, help="Max results (default: 10)")
     parser.add_argument("--reindex", action="store_true", help="Force full rebuild of the index")
 

--- a/tests/test_grok_parser.py
+++ b/tests/test_grok_parser.py
@@ -151,6 +151,19 @@ class DetectGrokFormat(unittest.TestCase):
             ("assistant", "the toolchain is pinned to x86"),
         ])
 
+    def test_claude_turns_with_reminder_blocks_are_kept(self):
+        # Claude Code appends system-reminder blocks to genuine user prompts
+        # inside the same message; the grok-scoped markers leave those intact.
+        claude = Path(self.root) / "session.jsonl"
+        claude.write_text(json.dumps(
+            {"parentUuid": None, "type": "user", "message": {"role": "user", "content": [
+                {"type": "text", "text": "why does the deploy fail"},
+                {"type": "text", "text": "<system-reminder>CLAUDE.md contents</system-reminder>"},
+            ]}}) + "\n", encoding="utf-8")
+        turns = list(read_session.iter_messages(str(claude)))
+        self.assertEqual(len(turns), 1)
+        self.assertIn("why does the deploy fail", turns[0][1])
+
     def test_other_formats_are_still_detected(self):
         claude = Path(self.root) / "claude.jsonl"
         claude.write_text(json.dumps(

--- a/tests/test_grok_parser.py
+++ b/tests/test_grok_parser.py
@@ -1,0 +1,163 @@
+"""Tests for parse_grok_session and Grok detection in read_session.
+
+Grok session format (Grok CLI):
+  - One directory per session: ~/.grok/sessions/<percent-encoded-cwd>/<uuid>/
+  - Transcript at chat_history.jsonl; entries are {type, content} with no
+    timestamps of their own.
+  - Optional sibling summary.json supplies cwd, generated_title and created_at.
+  - Entries carrying "synthetic_reason" are harness context injected into the
+    turn list, not anything the user or the model said.
+
+Fixtures are generated as strings inside tmpdir — no fixture files committed.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.parse import quote
+
+# Make scripts/ importable as a module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import recall  # noqa: E402
+import read_session  # noqa: E402
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def write_session(root, entries, cwd="/home/u/project", uuid="0199-abc", summary=None):
+    """Lay out one Grok session directory and return its transcript path."""
+    session_dir = Path(root) / quote(cwd, safe="") / uuid
+    session_dir.mkdir(parents=True, exist_ok=True)
+    if summary is not None:
+        (session_dir / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    path = session_dir / "chat_history.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+    return str(path)
+
+
+CONVERSATION = [
+    {"type": "user", "content": "why does the build fail on arm"},
+    {"type": "assistant", "content": "the toolchain is pinned to x86"},
+    {"type": "reasoning", "content": "considering the toolchain"},
+    {"type": "tool_result", "content": "exit 1"},
+    {"type": "user", "content": "<system-reminder>injected</system-reminder>"},
+    {"type": "user", "content": "harness noise", "synthetic_reason": "context"},
+    {"type": "assistant", "content": ""},
+]
+
+
+class ParseGrokSession(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = tmp.name
+
+    def test_keeps_only_user_and_assistant_text(self):
+        path = write_session(self.root, CONVERSATION)
+        _, messages = recall.parse_grok_session(path)
+        self.assertEqual(messages, [
+            ("user", "why does the build fail on arm"),
+            ("assistant", "the toolchain is pinned to x86"),
+        ])
+
+    def test_skips_synthetic_harness_entries(self):
+        path = write_session(self.root, CONVERSATION)
+        _, messages = recall.parse_grok_session(path)
+        self.assertNotIn("harness noise", [text for _, text in messages])
+
+    def test_session_id_and_source_come_from_the_directory(self):
+        path = write_session(self.root, CONVERSATION, uuid="0199-def")
+        metadata, _ = recall.parse_grok_session(path)
+        self.assertEqual(metadata["session_id"], "0199-def")
+        self.assertEqual(metadata["source"], "grok")
+        self.assertEqual(metadata["file_path"], path)
+
+    def test_project_is_decoded_from_the_parent_directory(self):
+        path = write_session(self.root, CONVERSATION, cwd="/home/u/my project")
+        metadata, _ = recall.parse_grok_session(path)
+        self.assertEqual(metadata["project"], "/home/u/my project")
+
+    def test_summary_supplies_project_title_and_time(self):
+        path = write_session(self.root, CONVERSATION, summary={
+            "info": {"cwd": "/srv/app"},
+            "generated_title": "arm build failure",
+            "created_at": "2026-05-01T12:00:00.000Z",
+        })
+        metadata, _ = recall.parse_grok_session(path)
+        self.assertEqual(metadata["project"], "/srv/app")
+        self.assertEqual(metadata["slug"], "arm build failure")
+        self.assertEqual(metadata["timestamp"],
+                         recall.parse_iso_timestamp("2026-05-01T12:00:00.000Z"))
+
+    def test_git_root_is_used_when_summary_has_no_cwd(self):
+        path = write_session(self.root, CONVERSATION,
+                             summary={"git_root_dir": "/srv/repo"})
+        metadata, _ = recall.parse_grok_session(path)
+        self.assertEqual(metadata["project"], "/srv/repo")
+
+    def test_slug_falls_back_to_the_session_id(self):
+        path = write_session(self.root, CONVERSATION, uuid="0199abcdef123456")
+        metadata, _ = recall.parse_grok_session(path)
+        self.assertEqual(metadata["slug"], "0199abcdef12")
+
+    def test_a_corrupt_summary_does_not_stop_the_parse(self):
+        path = write_session(self.root, CONVERSATION)
+        (Path(path).parent / "summary.json").write_text("{not json", encoding="utf-8")
+        metadata, messages = recall.parse_grok_session(path)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(metadata["project"], "/home/u/project")
+
+    def test_a_corrupt_line_costs_only_that_line(self):
+        path = write_session(self.root, CONVERSATION)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("{not json\n")
+            f.write(json.dumps({"type": "user", "content": "after the corruption"}) + "\n")
+        _, messages = recall.parse_grok_session(path)
+        self.assertIn("after the corruption", [text for _, text in messages])
+
+    def test_an_empty_transcript_parses(self):
+        path = write_session(self.root, [])
+        metadata, messages = recall.parse_grok_session(path)
+        self.assertEqual(messages, [])
+        self.assertEqual(metadata["timestamp"], 0)
+
+    def test_a_missing_file_is_reported_not_raised(self):
+        self.assertIsNone(recall.parse_grok_session(
+            str(Path(self.root) / "nowhere" / "chat_history.jsonl")))
+
+
+class DetectGrokFormat(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = tmp.name
+
+    def test_detects_grok_by_transcript_name(self):
+        path = write_session(self.root, CONVERSATION)
+        self.assertEqual(read_session.detect_format(path), "grok")
+
+    def test_reads_the_same_turns_recall_indexes(self):
+        path = write_session(self.root, CONVERSATION)
+        turns = list(read_session.iter_messages(path))
+        self.assertEqual(turns, [
+            ("user", "why does the build fail on arm"),
+            ("assistant", "the toolchain is pinned to x86"),
+        ])
+
+    def test_other_formats_are_still_detected(self):
+        claude = Path(self.root) / "claude.jsonl"
+        claude.write_text(json.dumps(
+            {"parentUuid": None, "type": "user",
+             "message": {"content": "hi"}}) + "\n", encoding="utf-8")
+        self.assertEqual(read_session.detect_format(str(claude)), "claude")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds [Grok CLI](https://github.com/xai-org/grok-cli) as a fourth source, next to Claude Code, Codex and pi. Independent of #11 — either can go in first.

## Layout

Grok is laid out differently from the other three, so it needs its own parser rather than a variation on one:

```
~/.grok/sessions/<percent-encoded-cwd>/<uuid>/
    chat_history.jsonl     the transcript
    summary.json           optional: generated_title, info.cwd, created_at
```

- A session is a **directory**, not a file, and every transcript has the same name.
- The **cwd is percent-encoded into the parent directory name**, so the project path is recovered with `unquote` when `summary.json` is absent.
- Transcript entries carry **no timestamps at all**. The session's time comes from `summary.json`'s `created_at`, or stays 0.
- The generated title often lands in `summary.json` after the session has started, so it is read on every pass rather than cached.

## What gets skipped

Two things that would otherwise swamp results:

- Entries carrying `synthetic_reason` — harness context Grok injects into the turn list, not anything the user or the model said.
- `<user_info>`, `<system-reminder>` and `<git_status>` blocks, which Grok wraps into genuine user turns. Added to `read_session.py`'s `SKIP_MARKERS` for the same reason.

Only `user`/`assistant` entries are indexed, matching the other three parsers; `reasoning` and `tool_result` are dropped.

## read_session.py

Grok is detected by path rather than content — every transcript is `chat_history.jsonl` and the entries are `{type, content}`, too plain to distinguish from the others on the first line. The content check stays as a fallback for a file reached by some other path.

## Tests

`tests/test_grok_parser.py`, matching the style of `test_pi_parser.py` — fixtures built as strings in a tmpdir, nothing committed. Covers the parser, `summary.json` and its fallbacks, the percent-decoded cwd, corrupt summary and corrupt lines, empty and missing files, and format detection.

```
python3 -m unittest discover tests -v
Ran 42 tests — OK
```

Existing tests unchanged and passing. No schema change; `--reindex` once picks up existing Grok sessions.