### PR TITLE
Index only what a session has added since the last run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- Index only the bytes a session has added since the last run, rather than
+  deleting and re-parsing every file whose mtime moved. Sessions carry a
+  `byte_offset`, a hash of the 4 KB before it, and a `parser_version`; if any
+  of the three fails to line up the file is read in full as before.
+- Applies to Claude Code and Codex. pi keeps the full-read path until its
+  write behaviour is confirmed — see `APPEND_ONLY_SOURCES`.
+- Existing indexes upgrade in place. Each session is read in full once more and
+  picks up a resume point from then on; no reindex needed.
+- A file that cannot be read keeps whatever is already indexed for it, instead
+  of being pruned before the parse is attempted.
+
 ## 0.4.1
 
 - Make the positional `query` argument optional. When omitted, list every

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -3,6 +3,7 @@
 
 import argparse
 import fcntl
+import hashlib
 import json
 import os
 import re
@@ -10,6 +11,7 @@ import sqlite3
 import sys
 import math
 import time
+from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime
 from glob import glob
@@ -29,6 +31,27 @@ PI_SESSIONS_DIR = PI_DIR / "agent" / "sessions"
 # searching the index as it stands. Waiting forever would turn one stalled
 # process into a hang in every other session.
 LOCK_WAIT_SECONDS = 20
+
+# Sources that only ever append to a transcript, so a byte offset into one
+# still means what it meant last run. pi is left out until someone who runs it
+# can confirm it never rewrites a session in place; it costs only a full read.
+APPEND_ONLY_SOURCES = {"claude", "codex"}
+
+# Bytes before a resume point that must still match for a tail read to be safe.
+# Removing a message from the middle of a transcript shifts every later byte,
+# which lands inside this window; 4 KB is far more than one entry.
+TAIL_WINDOW = 4096
+
+# Stored per session. Bump it when a parser starts keeping or dropping
+# different text, so sessions already indexed are read again rather than
+# keeping a mix of old and new parsing for good.
+PARSER_VERSION = 1
+
+# What the index already holds for one session file.
+Indexed = namedtuple(
+    "Indexed",
+    "session_id mtime byte_offset tail_hash parser_version project slug timestamp",
+)
 
 
 @contextmanager
@@ -83,7 +106,10 @@ def create_schema(conn):
             project TEXT,
             slug TEXT,
             timestamp INTEGER,
-            mtime REAL
+            mtime REAL,
+            byte_offset INTEGER DEFAULT 0,
+            tail_hash TEXT,
+            parser_version INTEGER DEFAULT 0
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS messages USING fts5(
@@ -102,19 +128,30 @@ def create_schema(conn):
     """)
 
 
-def migrate_schema(conn):
-    """Add columns if upgrading from an older schema."""
-    try:
-        conn.execute("SELECT source FROM sessions LIMIT 1")
-    except sqlite3.OperationalError:
-        conn.execute("ALTER TABLE sessions ADD COLUMN source TEXT DEFAULT 'claude'")
-        conn.commit()
-    try:
-        conn.execute("SELECT file_path FROM sessions LIMIT 1")
-    except sqlite3.OperationalError:
-        conn.execute("ALTER TABLE sessions ADD COLUMN file_path TEXT DEFAULT ''")
-        conn.commit()
+ADDED_COLUMNS = (
+    ("source", "TEXT DEFAULT 'claude'"),
+    ("file_path", "TEXT DEFAULT ''"),
+    ("byte_offset", "INTEGER DEFAULT 0"),
+    ("tail_hash", "TEXT"),
+    ("parser_version", "INTEGER DEFAULT 0"),
+)
 
+
+def migrate_schema(conn):
+    """Add whatever columns an index built by an older version is missing.
+
+    Rows keep byte_offset 0, so each session is read in full once more and
+    picks up a resume point from then on. No rebuild needed.
+    """
+    present = {row[1] for row in conn.execute("PRAGMA table_info(sessions)")}
+    for name, definition in ADDED_COLUMNS:
+        if name not in present:
+            conn.execute(f"ALTER TABLE sessions ADD COLUMN {name} {definition}")
+    if "parser_version" not in present:
+        # Sessions already indexed were parsed by the parsers as they stand.
+        # Stamping them says so, rather than making every one be read again.
+        conn.execute("UPDATE sessions SET parser_version = ?", (PARSER_VERSION,))
+    conn.commit()
 
 
 def migrate_db_location():
@@ -131,6 +168,75 @@ def migrate_db_location():
 
 TEXT_BLOCK_TYPES = {"text", "input_text", "output_text"}
 CODEX_SKIP_MARKERS = ("<user_instructions>", "<environment_context>", "<permissions instructions>", "# AGENTS.md instructions")
+
+
+def read_complete_lines(path, start=0):
+    """Yield (line, offset just past it) for whole lines from `start`.
+
+    Iterating the file reads a buffer at a time, so a very large transcript
+    costs no more memory than its longest line. A session being written can end
+    mid-line, and that fragment is left for the next run rather than parsed
+    into half a message.
+    """
+    with open(path, "rb") as f:
+        f.seek(start)
+        offset = start
+        for raw in f:
+            # Only the last line can lack its newline, and only while it is
+            # still being written.
+            if not raw.endswith(b"\n"):
+                return
+            offset += len(raw)
+            yield raw.decode("utf-8", errors="replace"), offset
+
+
+def iter_entries(path, start=0):
+    """Yield (decoded entry, offset just past its line) for each JSON line.
+
+    Blank and unparseable lines are skipped, as every parser here has always
+    done — a corrupt line should cost one message, not the session.
+    """
+    for line, offset in read_complete_lines(path, start):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        yield entry, offset
+
+
+def tail_hash_at(path, offset):
+    """Fingerprint the bytes just before `offset` — what was indexed up to.
+
+    Comparing this against the stored value answers the only question a tail
+    read depends on: is this still the file we left off in the middle of?
+    """
+    window = min(TAIL_WINDOW, offset)
+    if window <= 0:
+        return None
+    try:
+        with open(path, "rb") as f:
+            f.seek(offset - window)
+            data = f.read(window)
+    except OSError:
+        return None
+    if len(data) != window:
+        return None
+    return hashlib.sha256(data).hexdigest()
+
+
+def resume_offset(path, offset, tail_hash, parser_version):
+    """Offset to resume parsing from, or 0 when the file must be read in full.
+
+    A file that was only appended to still carries the bytes hashed last time.
+    One that was truncated, replaced, or had an entry removed from the middle
+    does not, and is read again from the start.
+    """
+    if not offset or not tail_hash or parser_version != PARSER_VERSION:
+        return 0
+    return offset if tail_hash_at(path, offset) == tail_hash else 0
 
 
 def extract_text(content):
@@ -168,68 +274,66 @@ def parse_iso_timestamp(ts_str):
 
 # — Claude Code session parser —————————————————————————————————————————————
 
-def parse_claude_session(path):
-    """Parse a Claude Code JSONL session file, returning (metadata, messages)."""
+def parse_claude_session(path, start=0):
+    """Parse a Claude Code JSONL session file.
+
+    Returns (metadata, messages, offset just past the last complete line).
+    With `start` past 0 only the bytes after it are read, so the metadata
+    reflects the tail alone and the caller keeps what it already stored.
+    """
     session_id = Path(path).stem
     project = None
     slug = None
     earliest_ts = None
     messages = []
 
+    end_offset = start
+
     try:
-        with open(path, "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
+        for entry, end_offset in iter_entries(path, start):
+            etype = entry.get("type", "")
 
-                etype = entry.get("type", "")
+            # Extract cwd from any entry
+            if not project:
+                cwd = entry.get("cwd", "")
+                if cwd:
+                    project = cwd
 
-                # Extract cwd from any entry
-                if not project:
-                    cwd = entry.get("cwd", "")
-                    if cwd:
-                        project = cwd
+            # Extract slug from any entry
+            if not slug:
+                slug = entry.get("slug", "") or entry.get("leafName", "")
 
-                # Extract slug from any entry
-                if not slug:
-                    slug = entry.get("slug", "") or entry.get("leafName", "")
+            # Parse timestamp
+            ts_raw = entry.get("timestamp")
+            ts_ms = parse_iso_timestamp(ts_raw)
+            if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
+                earliest_ts = ts_ms
 
-                # Parse timestamp
-                ts_raw = entry.get("timestamp")
-                ts_ms = parse_iso_timestamp(ts_raw)
-                if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
-                    earliest_ts = ts_ms
-
-                # Determine role: check both "type" and "role" fields
-                role = entry.get("role", "")
-                if role not in ("user", "assistant"):
-                    if etype == "user" or etype == "human":
-                        role = "user"
-                    elif etype == "assistant":
-                        role = "assistant"
-                    else:
-                        continue
-
-                # Extract text content — handle multiple formats:
-                # 1. {message: {content: "..."}} or {message: {content: [{type:"text",...}]}}
-                # 2. {content: "..."} or {content: [...]}
-                content = entry.get("message", {})
-                if isinstance(content, dict):
-                    content = content.get("content", "")
-                elif isinstance(content, str):
-                    # message field is a plain string
-                    pass
+            # Determine role: check both "type" and "role" fields
+            role = entry.get("role", "")
+            if role not in ("user", "assistant"):
+                if etype == "user" or etype == "human":
+                    role = "user"
+                elif etype == "assistant":
+                    role = "assistant"
                 else:
-                    content = entry.get("content", "")
+                    continue
 
-                text = extract_text(content)
-                if text:
-                    messages.append((role, text))
+            # Extract text content — handle multiple formats:
+            # 1. {message: {content: "..."}} or {message: {content: [{type:"text",...}]}}
+            # 2. {content: "..."} or {content: [...]}
+            content = entry.get("message", {})
+            if isinstance(content, dict):
+                content = content.get("content", "")
+            elif isinstance(content, str):
+                # message field is a plain string
+                pass
+            else:
+                content = entry.get("content", "")
+
+            text = extract_text(content)
+            if text:
+                messages.append((role, text))
 
     except (OSError, PermissionError) as e:
         print(f"Warning: skipping {path}: {e}", file=sys.stderr)
@@ -246,12 +350,12 @@ def parse_claude_session(path):
         "slug": slug,
         "timestamp": earliest_ts or 0,
     }
-    return metadata, messages
+    return metadata, messages, end_offset
 
 
 # — Codex session parser ———————————————————————————————————————————————————
 
-def parse_codex_session(path):
+def parse_codex_session(path, start=0):
     """Parse a Codex JSONL session file, returning (metadata, messages).
 
     Codex sessions live in ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl.
@@ -275,84 +379,77 @@ def parse_codex_session(path):
         session_id,
     )
 
+    end_offset = start
+
     try:
-        with open(path, "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
+        for entry, end_offset in iter_entries(path, start):
+            # Skip state snapshots (legacy format)
+            if entry.get("record_type") == "state":
+                continue
 
-                # Skip state snapshots (legacy format)
-                if entry.get("record_type") == "state":
-                    continue
+            # Parse timestamp (present in both formats at top level)
+            ts_raw = entry.get("timestamp")
+            if ts_raw:
+                ts_ms = parse_iso_timestamp(ts_raw)
+                if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
+                    earliest_ts = ts_ms
 
-                # Parse timestamp (present in both formats at top level)
-                ts_raw = entry.get("timestamp")
-                if ts_raw:
-                    ts_ms = parse_iso_timestamp(ts_raw)
-                    if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
-                        earliest_ts = ts_ms
+            etype = entry.get("type", "")
 
-                etype = entry.get("type", "")
+            # Current format: {type: "session_meta", payload: {id, cwd, ...}}
+            if etype == "session_meta":
+                payload = entry.get("payload", {})
+                entry_id = payload.get("id", "")
+                if entry_id and session_id.startswith("rollout-"):
+                    session_id = entry_id
+                if not project:
+                    project = payload.get("cwd", "")
+                continue
 
-                # Current format: {type: "session_meta", payload: {id, cwd, ...}}
-                if etype == "session_meta":
-                    payload = entry.get("payload", {})
-                    entry_id = payload.get("id", "")
+            # Current format: {type: "response_item", payload: {role, content, ...}}
+            # Legacy format: {role, content, ...} (no type or type="message")
+            if etype == "response_item":
+                payload = entry.get("payload", {})
+                role = payload.get("role", "")
+                content = payload.get("content", "")
+            elif etype in ("event_msg", "turn_context"):
+                continue
+            else:
+                # Legacy format — session metadata in first entry
+                if not project and "id" in entry and "instructions" in entry:
+                    entry_id = entry.get("id", "")
                     if entry_id and session_id.startswith("rollout-"):
                         session_id = entry_id
-                    if not project:
-                        project = payload.get("cwd", "")
                     continue
 
-                # Current format: {type: "response_item", payload: {role, content, ...}}
-                # Legacy format: {role, content, ...} (no type or type="message")
-                if etype == "response_item":
-                    payload = entry.get("payload", {})
-                    role = payload.get("role", "")
-                    content = payload.get("content", "")
-                elif etype in ("event_msg", "turn_context"):
-                    continue
-                else:
-                    # Legacy format — session metadata in first entry
-                    if not project and "id" in entry and "instructions" in entry:
-                        entry_id = entry.get("id", "")
-                        if entry_id and session_id.startswith("rollout-"):
-                            session_id = entry_id
-                        continue
+                role = entry.get("role", "")
+                content = entry.get("content", "")
 
-                    role = entry.get("role", "")
-                    content = entry.get("content", "")
+                # Legacy: extract cwd from <environment_context> blocks
+                if not project and isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict):
+                            text = block.get("text", "")
+                            if "Current working directory:" in text:
+                                cwd_match = re.search(
+                                    r"Current working directory:\s*(.+)", text
+                                )
+                                if cwd_match:
+                                    project = cwd_match.group(1).strip()
 
-                    # Legacy: extract cwd from <environment_context> blocks
-                    if not project and isinstance(content, list):
-                        for block in content:
-                            if isinstance(block, dict):
-                                text = block.get("text", "")
-                                if "Current working directory:" in text:
-                                    cwd_match = re.search(
-                                        r"Current working directory:\s*(.+)", text
-                                    )
-                                    if cwd_match:
-                                        project = cwd_match.group(1).strip()
+            # Only index user and assistant messages (skip developer/system)
+            if role not in ("user", "assistant"):
+                continue
 
-                # Only index user and assistant messages (skip developer/system)
-                if role not in ("user", "assistant"):
-                    continue
+            text = extract_text(content)
 
-                text = extract_text(content)
+            # Skip system/instruction blocks injected as user messages
+            if not text:
+                continue
+            if any(marker in text for marker in CODEX_SKIP_MARKERS):
+                continue
 
-                # Skip system/instruction blocks injected as user messages
-                if not text:
-                    continue
-                if any(marker in text for marker in CODEX_SKIP_MARKERS):
-                    continue
-
-                messages.append((role, text))
+            messages.append((role, text))
 
     except (OSError, PermissionError) as e:
         print(f"Warning: skipping {path}: {e}", file=sys.stderr)
@@ -370,12 +467,12 @@ def parse_codex_session(path):
         "slug": slug,
         "timestamp": earliest_ts or 0,
     }
-    return metadata, messages
+    return metadata, messages, end_offset
 
 
 # — Pi session parser ——————————————————————————————————————————————————————
 
-def parse_pi_session(path):
+def parse_pi_session(path, start=0):
     """Parse a pi (earendil-works/pi-coding-agent) JSONL session file.
 
     Pi sessions live in ~/.pi/agent/sessions/--<encoded-cwd>--/<ts>_<uuid>.jsonl.
@@ -403,57 +500,50 @@ def parse_pi_session(path):
         session_id,
     )
 
+    end_offset = start
+
     try:
-        with open(path, "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
+        for entry, end_offset in iter_entries(path, start):
+            etype = entry.get("type", "")
 
-                etype = entry.get("type", "")
-
-                # Session header — first line, metadata only.
-                if etype == "session":
-                    entry_id = entry.get("id", "")
-                    if entry_id:
-                        session_id = entry_id
-                    if not project:
-                        project = entry.get("cwd", "")
-                    ts_ms = parse_iso_timestamp(entry.get("timestamp"))
-                    if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
-                        earliest_ts = ts_ms
-                    continue
-
-                # Skip everything that isn't a conversational message:
-                # custom (extension state), custom_message (extension-injected),
-                # session_info (display name), model_change, thinking_level_change,
-                # compaction, branch_summary, label.
-                if etype != "message":
-                    continue
-
-                # Track earliest entry timestamp defensively in case the header
-                # is missing or files are partially written.
+            # Session header — first line, metadata only.
+            if etype == "session":
+                entry_id = entry.get("id", "")
+                if entry_id:
+                    session_id = entry_id
+                if not project:
+                    project = entry.get("cwd", "")
                 ts_ms = parse_iso_timestamp(entry.get("timestamp"))
                 if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
                     earliest_ts = ts_ms
+                continue
 
-                msg = entry.get("message", {})
-                if not isinstance(msg, dict):
-                    continue
+            # Skip everything that isn't a conversational message:
+            # custom (extension state), custom_message (extension-injected),
+            # session_info (display name), model_change, thinking_level_change,
+            # compaction, branch_summary, label.
+            if etype != "message":
+                continue
 
-                role = msg.get("role", "")
-                # Only index user and assistant messages — skip toolResult,
-                # bashExecution, and any other non-conversational roles.
-                if role not in ("user", "assistant"):
-                    continue
+            # Track earliest entry timestamp defensively in case the header
+            # is missing or files are partially written.
+            ts_ms = parse_iso_timestamp(entry.get("timestamp"))
+            if ts_ms and (earliest_ts is None or ts_ms < earliest_ts):
+                earliest_ts = ts_ms
 
-                text = extract_text(msg.get("content", ""))
-                if text:
-                    messages.append((role, text))
+            msg = entry.get("message", {})
+            if not isinstance(msg, dict):
+                continue
+
+            role = msg.get("role", "")
+            # Only index user and assistant messages — skip toolResult,
+            # bashExecution, and any other non-conversational roles.
+            if role not in ("user", "assistant"):
+                continue
+
+            text = extract_text(msg.get("content", ""))
+            if text:
+                messages.append((role, text))
 
     except (OSError, PermissionError) as e:
         print(f"Warning: skipping {path}: {e}", file=sys.stderr)
@@ -473,7 +563,7 @@ def parse_pi_session(path):
         "slug": slug,
         "timestamp": earliest_ts or 0,
     }
-    return metadata, messages
+    return metadata, messages, end_offset
 
 
 # — Indexing ———————————————————————————————————————————————————————————————
@@ -488,12 +578,13 @@ def index_sessions(conn, force=False):
         """)
 
     # Get existing mtimes keyed by file_path (stable across session_id changes)
-    existing = {}
-    try:
-        for row in conn.execute("SELECT file_path, session_id, mtime FROM sessions"):
-            existing[row[0]] = (row[1], row[2])
-    except sqlite3.OperationalError:
-        pass
+    existing = {
+        row[0]: Indexed(*row[1:])
+        for row in conn.execute(
+            "SELECT file_path, session_id, mtime, byte_offset, tail_hash, "
+            "parser_version, project, slug, timestamp FROM sessions"
+        )
+    }
 
     # Collect files from both sources
     sources = []
@@ -526,36 +617,67 @@ def index_sessions(conn, force=False):
         except OSError:
             continue
 
-        if not force and fpath in existing and existing[fpath][1] == mtime:
+        prior = existing.get(fpath)
+        if prior and prior.mtime == mtime and prior.parser_version == PARSER_VERSION:
             skipped += 1
             continue
 
-        # Remove old data for this file if re-indexing
-        if fpath in existing:
-            old_sid = existing[fpath][0]
-            conn.execute("DELETE FROM sessions WHERE session_id = ?", (old_sid,))
-            conn.execute("DELETE FROM messages WHERE session_id = ?", (old_sid,))
-            conn.execute("DELETE FROM messages_cjk WHERE session_id = ?", (old_sid,))
+        # Read only what is new, where the source only appends and the bytes
+        # left off after are still the ones hashed last time.
+        start = 0
+        if prior and source in APPEND_ONLY_SOURCES:
+            start = resume_offset(fpath, prior.byte_offset, prior.tail_hash,
+                                  prior.parser_version)
 
         if source == "claude":
-            result = parse_claude_session(fpath)
+            result = parse_claude_session(fpath, start)
         elif source == "codex":
-            result = parse_codex_session(fpath)
+            result = parse_codex_session(fpath, start)
         else:  # pi
-            result = parse_pi_session(fpath)
+            result = parse_pi_session(fpath, start)
 
+        # A file that could not be read keeps whatever is already indexed for
+        # it, rather than being pruned on a transient error.
         if result is None:
             continue
 
-        metadata, messages = result
+        # Remove old data for this file unless the read picked up where the
+        # last one stopped.
+        if prior and not start:
+            conn.execute("DELETE FROM sessions WHERE session_id = ?", (prior.session_id,))
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (prior.session_id,))
+            conn.execute("DELETE FROM messages_cjk WHERE session_id = ?", (prior.session_id,))
 
-        conn.execute(
-            "INSERT OR REPLACE INTO sessions (session_id, source, file_path, project, slug, timestamp, mtime) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (metadata["session_id"], metadata["source"], metadata["file_path"],
-             metadata["project"], metadata["slug"], metadata["timestamp"], mtime),
-        )
+        metadata, messages, end_offset = result
+        # Only record a resume point for a source worth resuming.
+        if source not in APPEND_ONLY_SOURCES:
+            end_offset = 0
+        tail_hash = tail_hash_at(fpath, end_offset)
 
-        msg_rows = [(metadata["session_id"], role, text) for role, text in messages]
+        if start:
+            # Only the tail was read, so merge the way a full read would: the
+            # first non-empty value wins, and the timestamp is the earliest
+            # seen anywhere in the file.
+            session_id = prior.session_id
+            stamps = [t for t in (prior.timestamp, metadata["timestamp"]) if t]
+            conn.execute(
+                "UPDATE sessions SET project = ?, slug = ?, timestamp = ?, "
+                "mtime = ?, byte_offset = ?, tail_hash = ?, parser_version = ? "
+                "WHERE session_id = ?",
+                (prior.project or metadata["project"], prior.slug or metadata["slug"],
+                 min(stamps) if stamps else 0,
+                 mtime, end_offset, tail_hash, PARSER_VERSION, session_id),
+            )
+        else:
+            session_id = metadata["session_id"]
+            conn.execute(
+                "INSERT OR REPLACE INTO sessions (session_id, source, file_path, project, slug, timestamp, mtime, byte_offset, tail_hash, parser_version) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (session_id, metadata["source"], metadata["file_path"],
+                 metadata["project"], metadata["slug"], metadata["timestamp"],
+                 mtime, end_offset, tail_hash, PARSER_VERSION),
+            )
+
+        msg_rows = [(session_id, role, text) for role, text in messages]
         conn.executemany(
             "INSERT INTO messages (session_id, role, text) VALUES (?, ?, ?)",
             msg_rows,

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,0 +1,477 @@
+"""Tests for incremental indexing.
+
+One property matters more than the rest: an index built up a piece at a time
+must hold exactly what an index built in one pass holds. The rest of this file
+is a catalogue of ways for that to break.
+
+Fixtures are generated as strings inside tmpdir — no fixture files committed,
+and nothing here reads real sessions or a real index.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+# Make scripts/ importable as a module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import recall  # noqa: E402
+
+BASE_MTIME = 1_800_000_000  # a fixed point in time; only the order matters
+
+
+class Corpus:
+    """A synthetic ~/.claude and ~/.codex under one root.
+
+    Every write moves the file's mtime forward a step. The scan decides what to
+    look at by mtime, and tests run faster than the clock ticks, so the step is
+    what makes them repeatable.
+    """
+
+    def __init__(self, root):
+        self.root = Path(root)
+        self.claude = self.root / "claude" / "projects"
+        self.codex = self.root / "codex" / "sessions"
+        self.pi = self.root / "pi" / "sessions"
+        for directory in (self.claude, self.codex, self.pi):
+            directory.mkdir(parents=True, exist_ok=True)
+        self._tick = 0
+
+    def write(self, path, entries, mode="a"):
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open(mode, encoding="utf-8") as handle:
+            for entry in entries:
+                handle.write(json.dumps(entry) + "\n")
+        self.stamp(path)
+        return path
+
+    def write_raw(self, path, text, mode="a"):
+        path = Path(path)
+        with path.open(mode, encoding="utf-8") as handle:
+            handle.write(text)
+        self.stamp(path)
+        return path
+
+    def stamp(self, path):
+        self._tick += 1
+        os.utime(path, (BASE_MTIME + self._tick, BASE_MTIME + self._tick))
+
+    def claude_session(self, session_id, entries, project="proj"):
+        return self.write(self.claude / project / f"{session_id}.jsonl", entries)
+
+    def codex_session(self, uuid, entries, day="2026/01/01"):
+        name = f"rollout-2026-01-01T00-00-00-{uuid}.jsonl"
+        return self.write(self.codex / day / name, entries)
+
+
+def claude_entry(text, role="user", cwd="/work/project", slug=None, ts=None):
+    entry = {"type": role, "cwd": cwd, "message": {"content": text}}
+    if slug:
+        entry["slug"] = slug
+    if ts:
+        entry["timestamp"] = ts
+    return entry
+
+
+def codex_meta(uuid, cwd="/work/project", ts="2026-01-01T00:00:00.000Z"):
+    return {"timestamp": ts, "type": "session_meta", "payload": {"id": uuid, "cwd": cwd}}
+
+
+def codex_entry(text, role="user", ts="2026-01-01T00:01:00.000Z"):
+    return {"timestamp": ts, "type": "response_item",
+            "payload": {"role": role, "content": [{"type": "input_text", "text": text}]}}
+
+
+CODEX_UUID = "019dff1d-385c-7822-8302-008a34dca659"
+
+
+class IncrementalCase(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name)
+        self.corpus = Corpus(self.tmp / "corpus")
+        self.db = str(self.tmp / "incremental.db")
+        self.rebuild_db = str(self.tmp / "rebuild.db")
+
+        for name, value in (("CLAUDE_DIR", self.corpus.root / "claude"),
+                            ("CLAUDE_PROJECTS_DIR", self.corpus.claude),
+                            ("CODEX_SESSIONS_DIR", self.corpus.codex),
+                            ("PI_SESSIONS_DIR", self.corpus.pi)):
+            self.addCleanup(setattr, recall, name, getattr(recall, name))
+            setattr(recall, name, value)
+
+    def index(self, db=None, force=False):
+        conn = sqlite3.connect(db or self.db)
+        try:
+            recall.create_schema(conn)
+            recall.migrate_schema(conn)
+            indexed, _, _, _ = recall.index_sessions(conn, force=force)
+            return indexed
+        finally:
+            conn.close()
+
+    def contents(self, db=None):
+        conn = sqlite3.connect(db or self.db)
+        try:
+            sessions = {row[0]: row[1:] for row in conn.execute(
+                "SELECT file_path, session_id, source, project, slug, timestamp FROM sessions")}
+            messages = {}
+            for session_id, role, text in conn.execute(
+                    "SELECT session_id, role, text FROM messages"):
+                messages.setdefault(session_id, Counter())[(role, text)] += 1
+            return sessions, messages
+        finally:
+            conn.close()
+
+    def assert_matches_rebuild(self):
+        self.index(db=self.rebuild_db, force=True)
+        self.assertEqual(self.contents(), self.contents(self.rebuild_db))
+
+    def row(self, path):
+        conn = sqlite3.connect(self.db)
+        try:
+            return conn.execute(
+                "SELECT session_id, byte_offset, tail_hash, parser_version, "
+                "project, slug, timestamp FROM sessions WHERE file_path = ?",
+                (str(path),)).fetchone()
+        finally:
+            conn.close()
+
+    def texts(self, session_id):
+        conn = sqlite3.connect(self.db)
+        try:
+            return sorted(row[0] for row in conn.execute(
+                "SELECT text FROM messages WHERE session_id = ?", (session_id,)))
+        finally:
+            conn.close()
+
+
+class GrowingSessions(IncrementalCase):
+    def test_matches_a_full_rebuild(self):
+        claude = self.corpus.claude_session("11111111-1111-1111-1111-111111111111", [
+            claude_entry("first turn", ts="2026-01-01T00:00:00.000Z"),
+            claude_entry("first reply", role="assistant")])
+        codex = self.corpus.codex_session(CODEX_UUID,
+                                          [codex_meta(CODEX_UUID), codex_entry("codex one")])
+        self.index()
+        for round_no in range(2, 5):
+            self.corpus.write(claude, [claude_entry(f"turn {round_no}")])
+            self.corpus.write(codex, [codex_entry(f"codex {round_no}")])
+            self.index()
+        self.assert_matches_rebuild()
+
+    def test_new_messages_are_not_duplicated(self):
+        path = self.corpus.claude_session("22222222-2222-2222-2222-222222222222",
+                                          [claude_entry("alpha")])
+        self.index()
+        self.corpus.write(path, [claude_entry("bravo")])
+        self.index()
+        self.assertEqual(self.texts(self.row(path)[0]), ["alpha", "bravo"])
+
+    def test_an_unchanged_file_is_not_read_again(self):
+        self.corpus.claude_session("33333333-3333-3333-3333-333333333333",
+                                   [claude_entry("only turn")])
+        self.assertEqual(self.index(), 1)
+        self.assertEqual(self.index(), 0)
+
+    def test_a_resume_point_is_recorded(self):
+        path = self.corpus.claude_session("44444444-4444-4444-4444-444444444444",
+                                          [claude_entry("turn")])
+        self.index()
+        _, offset, tail_hash, version, *_ = self.row(path)
+        self.assertEqual(offset, os.path.getsize(path))
+        self.assertIsNotNone(tail_hash)
+        self.assertEqual(version, recall.PARSER_VERSION)
+
+    def test_a_half_written_line_waits_for_the_rest(self):
+        path = self.corpus.claude_session("55555555-5555-5555-5555-555555555555",
+                                          [claude_entry("complete")])
+        self.index()
+        half = json.dumps(claude_entry("torn"))
+        self.corpus.write_raw(path, half[: len(half) // 2])
+        self.index()
+        self.assertEqual(self.texts(self.row(path)[0]), ["complete"])
+        self.corpus.write_raw(path, half[len(half) // 2:] + "\n")
+        self.index()
+        self.assertEqual(self.texts(self.row(path)[0]), ["complete", "torn"])
+        self.assert_matches_rebuild()
+
+
+class Mutations(IncrementalCase):
+    """A file that was not simply appended to must be read again in full."""
+
+    def session(self, count=6):
+        return self.corpus.claude_session(
+            "66666666-6666-6666-6666-666666666666",
+            [claude_entry(f"turn {i}") for i in range(count)])
+
+    def test_an_entry_removed_from_the_middle(self):
+        path = self.session()
+        self.index()
+        lines = Path(path).read_text(encoding="utf-8").splitlines(keepends=True)
+        del lines[2]
+        self.corpus.write_raw(path, "".join(lines), mode="w")
+        self.index()
+        self.assertNotIn("turn 2", self.texts(self.row(path)[0]))
+        self.assert_matches_rebuild()
+
+    def test_a_removal_hidden_by_later_appends(self):
+        """The file ends up longer than the resume point again, so only the
+        tail hash can tell that the bytes underneath it moved."""
+        path = self.session()
+        self.index()
+        lines = Path(path).read_text(encoding="utf-8").splitlines(keepends=True)
+        del lines[2]
+        self.corpus.write_raw(path, "".join(lines), mode="w")
+        self.corpus.write(path, [claude_entry(f"turn {i}") for i in range(6, 12)])
+        self.index()
+        texts = self.texts(self.row(path)[0])
+        self.assertNotIn("turn 2", texts)
+        self.assertIn("turn 11", texts)
+        self.assert_matches_rebuild()
+
+    def test_truncation(self):
+        path = self.session()
+        self.index()
+        self.corpus.write(path, [claude_entry("turn 0")], mode="w")
+        self.index()
+        self.assertEqual(self.texts(self.row(path)[0]), ["turn 0"])
+        self.assert_matches_rebuild()
+
+    def test_replacement_by_rename(self):
+        path = self.session()
+        self.index()
+        replacement = self.tmp / "replacement.jsonl"
+        replacement.write_text(json.dumps(claude_entry("fresh")) + "\n", encoding="utf-8")
+        os.replace(replacement, path)
+        self.corpus.stamp(path)
+        self.index()
+        self.assertEqual(self.texts(self.row(path)[0]), ["fresh"])
+        self.assert_matches_rebuild()
+
+    def test_an_edit_inside_the_tail_window(self):
+        path = self.session(4)
+        self.index()
+        text = Path(path).read_text(encoding="utf-8").replace("turn 3", "edited 3")
+        self.corpus.write_raw(path, text, mode="w")
+        self.index()
+        self.assertIn("edited 3", self.texts(self.row(path)[0]))
+        self.assert_matches_rebuild()
+
+
+class Metadata(IncrementalCase):
+    """A tail read sees only the end of a file. What the head supplied has to
+    survive rather than be overwritten with nothing."""
+
+    def test_the_earliest_timestamp_is_kept(self):
+        path = self.corpus.claude_session("77777777-7777-7777-7777-777777777777",
+                                          [claude_entry("open", ts="2026-01-01T00:00:00.000Z")])
+        self.index()
+        first = self.row(path)[6]
+        self.corpus.write(path, [claude_entry("later", ts="2026-06-01T00:00:00.000Z")])
+        self.index()
+        self.assertEqual(self.row(path)[6], first)
+
+    def test_an_earlier_timestamp_still_wins(self):
+        path = self.corpus.claude_session("88888888-8888-8888-8888-888888888888",
+                                          [claude_entry("open", ts="2026-06-01T00:00:00.000Z")])
+        self.index()
+        self.corpus.write(path, [claude_entry("older", ts="2026-01-01T00:00:00.000Z")])
+        self.index()
+        self.assertEqual(self.row(path)[6],
+                         recall.parse_iso_timestamp("2026-01-01T00:00:00.000Z"))
+        self.assert_matches_rebuild()
+
+    def test_the_first_slug_wins(self):
+        path = self.corpus.claude_session("99999999-9999-9999-9999-999999999999",
+                                          [claude_entry("open", slug="first-title")])
+        self.index()
+        self.corpus.write(path, [claude_entry("later", slug="second-title")])
+        self.index()
+        self.assertEqual(self.row(path)[5], "first-title")
+        self.assert_matches_rebuild()
+
+    def test_the_first_cwd_wins(self):
+        path = self.corpus.claude_session("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                                          [claude_entry("open", cwd="/first")])
+        self.index()
+        self.corpus.write(path, [claude_entry("later", cwd="/second")])
+        self.index()
+        self.assertEqual(self.row(path)[4], "/first")
+        self.assert_matches_rebuild()
+
+    def test_codex_keeps_the_id_from_its_first_line(self):
+        """Codex takes its session id from session_meta at the head, so a tail
+        read must not fall back to the rollout file name."""
+        path = self.corpus.codex_session(CODEX_UUID,
+                                         [codex_meta(CODEX_UUID), codex_entry("open")])
+        self.index()
+        self.assertEqual(self.row(path)[0], CODEX_UUID)
+        self.corpus.write(path, [codex_entry("later")])
+        self.index()
+        self.assertEqual(self.row(path)[0], CODEX_UUID)
+        self.assertEqual(self.texts(CODEX_UUID), ["later", "open"])
+
+
+class PiIsAlwaysReadInFull(IncrementalCase):
+    def test_pi_is_not_an_append_only_source(self):
+        self.assertNotIn("pi", recall.APPEND_ONLY_SOURCES)
+
+    def test_pi_rows_carry_no_resume_point(self):
+        path = self.corpus.write(self.corpus.pi / "s" / "2026-01-01T00_00_00_abc.jsonl", [
+            {"type": "session", "id": "abc", "cwd": "/work", "version": 3},
+            {"type": "message", "message": {"role": "user", "content": "hello pi"}}])
+        self.index()
+        self.assertEqual(self.row(path)[1], 0)
+
+
+class ParserVersion(IncrementalCase):
+    def test_a_bump_reaches_a_session_that_has_stopped_growing(self):
+        """Without this, a change to what the parsers keep would apply only to
+        sessions still being written."""
+        path = self.corpus.claude_session("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                                          [claude_entry("written once")])
+        self.index()
+        self.assertEqual(self.index(), 0)
+        original = recall.PARSER_VERSION
+        recall.PARSER_VERSION = original + 1
+        try:
+            self.assertEqual(self.index(), 1)
+            self.assertEqual(self.row(path)[3], original + 1)
+            self.assertEqual(self.texts(self.row(path)[0]), ["written once"])
+        finally:
+            recall.PARSER_VERSION = original
+
+
+class Migration(IncrementalCase):
+    OLD_SCHEMA = """
+        CREATE TABLE sessions (
+            session_id TEXT PRIMARY KEY, source TEXT, file_path TEXT,
+            project TEXT, slug TEXT, timestamp INTEGER, mtime REAL
+        );
+        CREATE VIRTUAL TABLE messages USING fts5(
+            session_id UNINDEXED, role, text, tokenize='porter unicode61');
+        CREATE VIRTUAL TABLE messages_cjk USING fts5(
+            session_id UNINDEXED, role, text, tokenize='trigram');
+    """
+
+    def test_an_older_index_gains_the_columns_in_place(self):
+        conn = sqlite3.connect(self.db)
+        conn.executescript(self.OLD_SCHEMA)
+        conn.execute("INSERT INTO sessions VALUES "
+                     "('old', 'claude', '/gone.jsonl', '/work', 'slug', 1700, 1.0)")
+        conn.execute("INSERT INTO messages VALUES ('old', 'user', 'kept text')")
+        conn.commit()
+        recall.migrate_schema(conn)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(sessions)")}
+        self.assertLessEqual({"byte_offset", "tail_hash", "parser_version"}, columns)
+        self.assertEqual(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0], 1)
+        self.assertEqual(conn.execute("SELECT text FROM messages").fetchone()[0],
+                         "kept text")
+        conn.close()
+
+    def test_existing_rows_are_read_in_full_once_more(self):
+        conn = sqlite3.connect(self.db)
+        conn.executescript(self.OLD_SCHEMA)
+        conn.execute("INSERT INTO sessions VALUES "
+                     "('old', 'claude', '/gone.jsonl', '/work', 'slug', 1700, 1.0)")
+        conn.commit()
+        recall.migrate_schema(conn)
+        offset, tail_hash, version = conn.execute(
+            "SELECT byte_offset, tail_hash, parser_version FROM sessions").fetchone()
+        self.assertEqual(recall.resume_offset("/gone.jsonl", offset, tail_hash, version), 0)
+        conn.close()
+
+    def test_migrating_twice_changes_nothing(self):
+        conn = sqlite3.connect(self.db)
+        conn.executescript(self.OLD_SCHEMA)
+        recall.migrate_schema(conn)
+        first = {row[1] for row in conn.execute("PRAGMA table_info(sessions)")}
+        recall.migrate_schema(conn)
+        self.assertEqual({row[1] for row in conn.execute("PRAGMA table_info(sessions)")},
+                         first)
+        conn.close()
+
+
+class Reader(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name)
+
+    def write(self, text):
+        path = self.tmp / "session.jsonl"
+        path.write_bytes(text.encode("utf-8"))
+        return str(path)
+
+    def read_all(self, path, start=0):
+        lines, offset = [], start
+        for line, line_end in recall.read_complete_lines(path, start):
+            lines.append(line)
+            offset = line_end
+        return lines, offset
+
+    def test_offsets_land_just_past_each_newline(self):
+        path = self.write("aa\nbbb\nc\n")
+        self.assertEqual([o for _, o in recall.read_complete_lines(path)], [3, 7, 9])
+
+    def test_a_partial_final_line_is_left_alone(self):
+        path = self.write('{"a":1}\n{"b":2}\n{"c":unfin')
+        lines, offset = self.read_all(path)
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(offset, 16)
+
+    def test_resuming_from_a_non_zero_start(self):
+        path = self.write("one\ntwo\nthree\n")
+        lines, offset = self.read_all(path, 4)
+        self.assertEqual(lines, ["two\n", "three\n"])
+        self.assertEqual(offset, 14)
+
+    def test_a_line_longer_than_the_read_buffer(self):
+        long_line = "x" * (4 << 20)
+        path = self.write(f"first\n{long_line}\nlast\n")
+        lines, offset = self.read_all(path)
+        self.assertEqual(lines[1], long_line + "\n")
+        self.assertEqual(offset, os.path.getsize(path))
+
+    def test_multibyte_characters_do_not_disturb_the_offset(self):
+        path = self.write("a" * 100 + "中文\n")
+        lines, offset = self.read_all(path)
+        self.assertNotIn("�", lines[0])
+        self.assertEqual(offset, os.path.getsize(path))
+
+    def test_an_empty_file(self):
+        self.assertEqual(self.read_all(self.write("")), ([], 0))
+
+    def test_resume_refuses_a_truncated_file(self):
+        path = self.write("alpha\nbravo\ncharlie\n")
+        offset = os.path.getsize(path)
+        stored = recall.tail_hash_at(path, offset)
+        Path(path).write_bytes(b"alpha\n")
+        self.assertEqual(recall.resume_offset(path, offset, stored,
+                                              recall.PARSER_VERSION), 0)
+
+    def test_resume_accepts_an_appended_file(self):
+        path = self.write("alpha\nbravo\n")
+        offset = os.path.getsize(path)
+        stored = recall.tail_hash_at(path, offset)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write("charlie\n")
+        self.assertEqual(recall.resume_offset(path, offset, stored,
+                                              recall.PARSER_VERSION), offset)
+
+    def test_resume_refuses_without_a_stored_hash(self):
+        path = self.write("alpha\n")
+        self.assertEqual(recall.resume_offset(path, 6, None, recall.PARSER_VERSION), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pi_parser.py
+++ b/tests/test_pi_parser.py
@@ -512,7 +512,7 @@ class TestRealPiSession(unittest.TestCase):
 
         result = recall.parse_pi_session(str(smallest))
         self.assertIsNotNone(result)
-        metadata, messages = result
+        metadata, messages, _ = result
         self.assertEqual(metadata["source"], "pi")
         self.assertTrue(metadata["session_id"])
         self.assertTrue(metadata["slug"])

--- a/tests/test_pi_parser.py
+++ b/tests/test_pi_parser.py
@@ -178,7 +178,7 @@ class TestParsePiSession(unittest.TestCase):
             "2026-05-06T13-50-25-335Z_019dfd8d-da36-7552-b0d5-dfa08528cf9b.jsonl",
             [PI_V3_SAMPLE[0]],
         )
-        metadata, messages = recall.parse_pi_session(path)
+        metadata, messages, _ = recall.parse_pi_session(path)
         self.assertEqual(metadata["session_id"], "019dfd8d-da36-7552-b0d5-dfa08528cf9b")
         self.assertEqual(metadata["source"], "pi")
         self.assertEqual(metadata["project"], "/Users/alice/Vaults/blog")
@@ -189,7 +189,7 @@ class TestParsePiSession(unittest.TestCase):
     def test_extracts_user_and_assistant_text(self):
         """User string content and assistant TextContent are both kept."""
         path = self._write("session.jsonl", PI_V3_SAMPLE)
-        _, messages = recall.parse_pi_session(path)
+        _, messages, _ = recall.parse_pi_session(path)
 
         roles = [m[0] for m in messages]
         texts = [m[1] for m in messages]
@@ -202,7 +202,7 @@ class TestParsePiSession(unittest.TestCase):
     def test_skips_thinking_toolcall_image_blocks(self):
         """Thinking, toolCall, and image blocks are dropped from assistant content."""
         path = self._write("session.jsonl", PI_V3_SAMPLE)
-        _, messages = recall.parse_pi_session(path)
+        _, messages, _ = recall.parse_pi_session(path)
 
         # Assistant turn had thinking + text + toolCall — only text should remain
         assistant_texts = [t for r, t in messages if r == "assistant"]
@@ -215,7 +215,7 @@ class TestParsePiSession(unittest.TestCase):
     def test_skips_toolresult_and_bashexecution(self):
         """toolResult and bashExecution roles produce no indexed messages."""
         path = self._write("session.jsonl", PI_V3_SAMPLE)
-        _, messages = recall.parse_pi_session(path)
+        _, messages, _ = recall.parse_pi_session(path)
 
         roles = [m[0] for m in messages]
         self.assertNotIn("toolResult", roles)
@@ -224,7 +224,7 @@ class TestParsePiSession(unittest.TestCase):
     def test_skips_non_message_top_level_types(self):
         """custom, custom_message, session_info, model_change, thinking_level_change skipped."""
         path = self._write("session.jsonl", PI_V3_SAMPLE)
-        _, messages = recall.parse_pi_session(path)
+        _, messages, _ = recall.parse_pi_session(path)
 
         joined = "\n".join(t for _, t in messages)
         self.assertNotIn("extension-injected note", joined)
@@ -264,20 +264,20 @@ class TestParsePiSession(unittest.TestCase):
             },
         ]
         path = self._write("session.jsonl", entries)
-        _, messages = recall.parse_pi_session(path)
+        _, messages, _ = recall.parse_pi_session(path)
         self.assertEqual(messages, [])
 
     def test_slug_includes_date_and_short_id(self):
         """Slug derived from filename: YYYY-MM-DD-<uuid8>."""
         name = "2026-05-06T13-50-25-335Z_019dfd8d-da36-7552-b0d5-dfa08528cf9b.jsonl"
         path = self._write(name, [PI_V3_SAMPLE[0]])
-        metadata, _ = recall.parse_pi_session(path)
+        metadata, _, _ = recall.parse_pi_session(path)
         self.assertEqual(metadata["slug"], "2026-05-06-019dfd8d")
 
     def test_slug_fallback_when_filename_unusual(self):
         """Filename without the expected pattern: slug falls back to a session-id prefix."""
         path = self._write("oddname.jsonl", [PI_V3_SAMPLE[0]])
-        metadata, _ = recall.parse_pi_session(path)
+        metadata, _, _ = recall.parse_pi_session(path)
         # Either short_id or session_id prefix — both are acceptable; just non-empty.
         self.assertTrue(metadata["slug"])
 
@@ -288,7 +288,7 @@ class TestParsePiSession(unittest.TestCase):
             f.write(json.dumps(PI_V3_SAMPLE[0]) + "\n")
             f.write("this is not json\n")
             f.write(json.dumps(PI_V3_SAMPLE[1]) + "\n")  # user message
-        _, messages = recall.parse_pi_session(str(path))
+        _, messages, _ = recall.parse_pi_session(str(path))
         self.assertEqual(len(messages), 1)
         self.assertEqual(messages[0][0], "user")
 
@@ -301,7 +301,7 @@ class TestParsePiSession(unittest.TestCase):
             f.write("\n\n")
             f.write(json.dumps(PI_V3_SAMPLE[1]) + "\n")
             f.write("\n")
-        _, messages = recall.parse_pi_session(str(path))
+        _, messages, _ = recall.parse_pi_session(str(path))
         self.assertEqual(len(messages), 1)
 
     def test_string_content_user_message(self):
@@ -317,7 +317,7 @@ class TestParsePiSession(unittest.TestCase):
             },
         ]
         path = self._write("session.jsonl", entries)
-        _, messages = recall.parse_pi_session(path)
+        _, messages, _ = recall.parse_pi_session(path)
         self.assertEqual(messages, [("user", "hello world")])
 
     def test_returns_none_on_unreadable_file(self):


### PR DESCRIPTION
**Builds on #11** — that PR's commit is included here, so review #11 first. Independent of #12.

## The problem

Every run deletes and re-parses each session file whose mtime has moved. If you keep sessions open, that is most of the recently used ones on every invocation.

The expensive half is not the parsing. `DELETE FROM messages WHERE session_id = ?` has no index it can use on an FTS5 table — `EXPLAIN QUERY PLAN` gives `SCAN messages VIRTUAL TABLE INDEX 0:` — so it walks the entire table once per changed file.

On a synthetic 372 MB / 4000 file corpus, after 150 sessions each gained one turn:

| | cold build | 150 files changed |
|---|---|---|
| today | 19.0s | **75.18s** |
| this PR | 16.2s | **1.51s** |

The re-index pass costing four times the cold build is that per-file scan.

## The change

Each session records three things: how far it was read (`byte_offset`), a hash of the `TAIL_WINDOW` bytes before that point (`tail_hash`), and `parser_version`.

If all three line up on the next run, only the bytes after the resume point are parsed and inserted — no delete, no re-parse of the prefix. If they do not, the file is read again from the start exactly as today.

The hash is the load-bearing part. Removing an entry from the middle of a transcript shifts every later byte, and further appends can push the file back past its old length, so a size check alone would accept a resume point whose underlying bytes have moved. Comparing 4 KB catches it.

## Scope

**Claude Code and Codex only.** pi stays on the full-read path — I have no pi sessions to check its write behaviour against, and guessing there would risk a silently wrong index. If you can confirm pi only ever appends, it is one entry in `APPEND_ONLY_SOURCES`.

## Two things a tail read forces

- **Metadata merges the way a full read resolves it.** A tail sees no `cwd`, no `slug` and only late timestamps, so it would otherwise overwrite what the head supplied. First non-empty `cwd` and `slug` win; the timestamp is the earliest anywhere in the file. This matters most for Codex, which takes its session id from `session_meta` on line 1.
- **A file that cannot be read keeps what is already indexed.** Rows were deleted before the parse was attempted, so a permission error or a transcript rotated away between the scan and the read silently dropped them. The delete now happens after a successful parse.

## Compatibility

Existing indexes gain the columns in place via `migrate_schema` — no reindex, no rebuild. Rows start with `byte_offset` 0, so each session is read in full once more and picks up a resume point from then on.

`parse_*_session` now returns `(metadata, messages, end_offset)`. `tests/test_pi_parser.py` is updated for the extra value; nothing else about it changes.

## Tests

`tests/test_incremental.py`, same conventions as the existing suite — synthetic fixtures in a tmpdir, nothing committed, no reads of real sessions or a real index.

The test that matters most builds an index a piece at a time and asserts it holds exactly what a full rebuild of the same corpus holds. Also covers mid-file removal, removal hidden by later appends, truncation, replacement by rename, an edit inside the tail window, half-written lines, the metadata merge, the parser-version bump, and migration from the older schema.

```
python3 -m unittest discover tests -v
Ran 65 tests — OK (skipped=1)
```

## Also worth knowing (not in this PR)

`--reindex` empties both tables and rebuilds from the files on disk, so it drops every session whose file no longer exists. On my index that is 2960 of 6908 — the tool has aged out those transcripts and the index is the only copy left. The deletes are also committed before the rebuild starts, so a rebuild that is interrupted leaves the index empty. Happy to send that separately if you'd like it fixed.