### PR TITLE
Fix the recency bias moving recent sessions down the page

### DIFF
--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -711,8 +711,10 @@ def search(conn, query, project=None, days=None, source=None, limit=10):
             recency_boost = math.exp(-0.693 * age_days / 30)  # half-life = 30 days
         else:
             recency_boost = 0.0
-        # Blend: 80% BM25, 20% recency. Recency term scales with typical BM25 magnitude.
-        blended_rank = rank * (1 - 0.2 * recency_boost)
+        # Blend: 80% BM25, 20% recency. bm25() is negative and results sort
+        # ascending, so a recent session has to be made *more* negative to move
+        # up. Subtracting moved it down the page instead.
+        blended_rank = rank * (1 + 0.2 * recency_boost)
 
         results.append((session_id, meta[0], meta[1], meta[2], meta[3], meta[4], excerpt, blended_rank))
 

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,103 @@
+"""Tests for the recency blend in search().
+
+bm25() returns a negative score and results sort ascending, so "better" means
+"more negative". Anything that multiplies the rank has to move a recent session
+away from zero, not toward it.
+
+Fixtures are generated as strings inside tmpdir — no fixture files committed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make scripts/ importable as a module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import recall  # noqa: E402
+
+
+class RecencyBias(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.projects = self.root / "projects"
+        self.db = str(self.root / "index.db")
+
+        for name, value in (("CLAUDE_DIR", self.root),
+                            ("CLAUDE_PROJECTS_DIR", self.projects),
+                            ("CODEX_SESSIONS_DIR", self.root / "none"),
+                            ("PI_SESSIONS_DIR", self.root / "none")):
+            self.addCleanup(setattr, recall, name, getattr(recall, name))
+            setattr(recall, name, value)
+
+    def seed(self, ages_in_days):
+        """One session per age, each matching the query exactly as well."""
+        now_ms = time.time() * 1000
+        for i, age in enumerate(ages_in_days):
+            when = datetime.fromtimestamp((now_ms - age * 86_400_000) / 1000,
+                                          tz=timezone.utc)
+            stamp = when.isoformat().replace("+00:00", "Z")
+            path = self.projects / "proj" / f"{i:08d}-0000-0000-0000-000000000000.jsonl"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({
+                "type": "user", "cwd": "/work", "timestamp": stamp,
+                "message": {"content": "distinctivetoken with some padding words"},
+            }) + "\n", encoding="utf-8")
+            # Keep mtimes distinct so the scan notices every file.
+            os.utime(path, (1_800_000_000 + i, 1_800_000_000 + i))
+
+        conn = sqlite3.connect(self.db)
+        recall.create_schema(conn)
+        recall.migrate_schema(conn)
+        recall.index_sessions(conn)
+        conn.commit()
+        return conn
+
+    def test_the_most_recent_of_equal_matches_comes_first(self):
+        conn = self.seed([400, 200, 1])
+        try:
+            results = recall.search(conn, "distinctivetoken", limit=3)
+            self.assertEqual(len(results), 3)
+            timestamps = [row[5] for row in results]
+            self.assertEqual(timestamps, sorted(timestamps, reverse=True))
+        finally:
+            conn.close()
+
+    def test_a_session_with_no_timestamp_ranks_last(self):
+        """boost 0 has to mean "as old as it gets", not "as good as it gets"."""
+        conn = self.seed([1])
+        try:
+            path = self.projects / "proj" / "undated.jsonl"
+            path.write_text(json.dumps({
+                "type": "user", "cwd": "/work",
+                "message": {"content": "distinctivetoken with some padding words"},
+            }) + "\n", encoding="utf-8")
+            os.utime(path, (1_800_000_100, 1_800_000_100))
+            recall.index_sessions(conn)
+            conn.commit()
+
+            results = recall.search(conn, "distinctivetoken", limit=2)
+            self.assertEqual(len(results), 2)
+            self.assertEqual(results[-1][5], 0)
+        finally:
+            conn.close()
+
+    def test_the_blend_never_moves_a_rank_toward_zero(self):
+        """Directly, without a corpus: a boost must only ever improve a score."""
+        for rank in (-0.000002, -5.16, -26.86):
+            for boost in (0.0, 0.5, 1.0):
+                with self.subTest(rank=rank, boost=boost):
+                    self.assertLessEqual(rank * (1 + 0.2 * boost), rank)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`bm25()` returns a **negative** score, and results are sorted ascending, so a better match is a *more negative* number.

```python
blended_rank = rank * (1 - 0.2 * recency_boost)
```

`(1 - 0.2·b)` with `b ∈ [0,1]` is between 0.8 and 1.0. Multiplying a negative number by something below 1 moves it **toward zero** — later in the sort.

So the boost runs backwards. A session from today gets factor 0.8, the largest demotion. A year-old one gets factor 1.0 and is left alone. The feature added in 0.2.2 to surface recent work has been burying it.

## Evidence

Fifteen real queries against a 197k-message index, comparing pure BM25 with the shipped blend. The blend makes the top ten **older in 10 of 15 queries and newer in none**. Median top-ten age for `subagent`: 41.6 → 58.4 days. For `tauri`: 62.8 → 83.3.

For `subagent`, all three of the most recent matches are evicted from the top five and a three-month-old, measurably worse match is pulled in:

| | pure BM25 | shipped blend |
|---|---|---|
|1| 2026-07-24 (−11.65) | 2026-06-12 (−11.45) |
|2| 2026-06-12 (−11.45) | 2026-06-19 (−11.27) |
|3| 2026-07-23 (−11.36) | 2026-06-02 (−10.85) |
|4| 2026-06-19 (−11.27) | 2026-06-01 (−10.63) |
|5| 2026-07-22 (−10.94) | 2026-04-15 (−9.74) |

Worse, in two of twenty queries the single best match falls off the first page — `recall.py` from position 1 to **24**, `tauri` to **18**. In both cases that match was also the most recent candidate, precisely what the boost exists to lift.

## The fix

Add the boost rather than subtract it, so a recent session is made more negative and moves up.

A session with `timestamp = 0` gets `recency_boost = 0.0`. Under the old arithmetic that was factor 1.0 — the *best* possible. It now correctly reads as "as old as it gets".

## Tests

`tests/test_ranking.py`, in the style of the existing suite — fixtures built as strings in a tmpdir, nothing committed:

- equally-good matches come back newest first
- a session with no timestamp ranks last
- the arithmetic never moves a rank toward zero, checked directly across the range of real BM25 magnitudes

I confirmed the tests catch it by restoring the old sign — two of the three fail. `python3 -m unittest discover tests -v` → 31 tests, OK.

One line of behaviour change, no schema change, no reindex.