### PR TITLE
Stop the role column being searchable

### DIFF
--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -49,14 +49,14 @@ def create_schema(conn):
 
         CREATE VIRTUAL TABLE IF NOT EXISTS messages USING fts5(
             session_id UNINDEXED,
-            role,
+            role UNINDEXED,
             text,
             tokenize='porter unicode61'
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS messages_cjk USING fts5(
             session_id UNINDEXED,
-            role,
+            role UNINDEXED,
             text,
             tokenize='trigram'
         );
@@ -76,6 +76,51 @@ def migrate_schema(conn):
         conn.execute("ALTER TABLE sessions ADD COLUMN file_path TEXT DEFAULT ''")
         conn.commit()
 
+
+
+# The two message tables, and the tokenizer each is built with.
+MESSAGE_TABLES = (("messages", "porter unicode61"), ("messages_cjk", "trigram"))
+
+
+def migrate_message_columns(conn):
+    """Rebuild any message table that still indexes the role column.
+
+    `role` holds the literal words "user" and "assistant", so indexing it made
+    both behave as wildcards: on a 197k-message index, `MATCH 'assistant'`
+    matched 172,597 rows, only 5,038 of which contain the word. FTS5 column
+    options cannot be altered, so the table is rebuilt from the rows already in
+    it — nothing is re-read from disk, which matters because sessions whose
+    files have since been deleted exist nowhere else.
+    """
+    for table, tokenize in MESSAGE_TABLES:
+        schema = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name = ?", (table,)).fetchone()
+        if not schema or "role UNINDEXED" in schema[0]:
+            continue
+
+        print(f"Rebuilding {table} so roles are no longer searchable...",
+              file=sys.stderr)
+        # One explicit transaction. Left to itself sqlite3 commits each DDL
+        # statement as it runs, so a run killed part way through would leave a
+        # half-built table that every later run then died on.
+        conn.execute("BEGIN")
+        try:
+            conn.execute(f"""
+                CREATE VIRTUAL TABLE {table}_rebuilt USING fts5(
+                    session_id UNINDEXED,
+                    role UNINDEXED,
+                    text,
+                    tokenize='{tokenize}'
+                )
+            """)
+            conn.execute(f"INSERT INTO {table}_rebuilt(session_id, role, text) "
+                         f"SELECT session_id, role, text FROM {table}")
+            conn.execute(f"DROP TABLE {table}")
+            conn.execute(f"ALTER TABLE {table}_rebuilt RENAME TO {table}")
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
 
 
 def migrate_db_location():
@@ -754,6 +799,7 @@ def main():
     conn.execute("PRAGMA synchronous=NORMAL")
     create_schema(conn)
     migrate_schema(conn)
+    migrate_message_columns(conn)
 
     # Index
     t0 = time.time()

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -947,12 +947,15 @@ def main():
     conn.execute("PRAGMA synchronous=NORMAL")
     create_schema(conn)
     migrate_schema(conn)
-    migrate_message_columns(conn)
 
-    # Index — one run at a time, so concurrent runs queue instead of colliding
+    # Index — one run at a time, so concurrent runs queue instead of colliding.
+    # The role-column rebuild takes seconds on a large index, well past
+    # SQLite's busy timeout, so it must sit inside the lock too; a run that
+    # doesn't get the lock searches the old schema, which still works.
     t0 = time.time()
     with index_lock() as have_lock:
         if have_lock:
+            migrate_message_columns(conn)
             indexed, skipped, total_sessions, total_messages = index_sessions(conn, force=args.reindex)
         else:
             indexed = 0

--- a/tests/test_role_column.py
+++ b/tests/test_role_column.py
@@ -1,0 +1,177 @@
+"""Tests for the role column not being searchable.
+
+`role` holds the literal strings "user" and "assistant". Indexing it made both
+words match almost every message in the corpus rather than the ones that say
+them, so any query containing either was silently narrowed.
+
+Fixtures are generated as strings inside tmpdir — no fixture files committed.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+# Make scripts/ importable as a module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import recall  # noqa: E402
+
+OLD_SCHEMA = """
+    CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY, source TEXT, file_path TEXT,
+        project TEXT, slug TEXT, timestamp INTEGER, mtime REAL);
+    CREATE VIRTUAL TABLE messages USING fts5(
+        session_id UNINDEXED, role, text, tokenize='porter unicode61');
+    CREATE VIRTUAL TABLE messages_cjk USING fts5(
+        session_id UNINDEXED, role, text, tokenize='trigram');
+"""
+
+
+class RolesAreNotSearchable(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.projects = self.root / "projects"
+        self.db = str(self.root / "index.db")
+
+        for name, value in (("CLAUDE_DIR", self.root),
+                            ("CLAUDE_PROJECTS_DIR", self.projects),
+                            ("CODEX_SESSIONS_DIR", self.root / "none"),
+                            ("PI_SESSIONS_DIR", self.root / "none")):
+            self.addCleanup(setattr, recall, name, getattr(recall, name))
+            setattr(recall, name, value)
+
+    def session(self, name, entries):
+        path = self.projects / "proj" / f"{name}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("".join(json.dumps(e) + "\n" for e in entries), encoding="utf-8")
+        os.utime(path, (1_800_000_000, 1_800_000_000))
+        return path
+
+    def indexed(self):
+        conn = sqlite3.connect(self.db)
+        recall.create_schema(conn)
+        recall.migrate_schema(conn)
+        recall.index_sessions(conn)
+        conn.commit()
+        return conn
+
+    def test_a_role_name_matches_only_messages_that_say_it(self):
+        self.session("aaaa", [
+            {"type": "user", "cwd": "/w", "message": {"content": "a question about rust"}},
+            {"type": "assistant", "message": {"content": "an answer about rust"}}])
+        self.session("bbbb", [
+            {"type": "user", "cwd": "/w",
+             "message": {"content": "the word assistant appears here"}}])
+        conn = self.indexed()
+        try:
+            hits = conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE messages MATCH 'assistant'").fetchone()[0]
+            self.assertEqual(hits, 1)
+        finally:
+            conn.close()
+
+    def test_a_role_word_does_not_narrow_an_ordinary_query(self):
+        self.session("cccc", [
+            {"type": "user", "cwd": "/w", "message": {"content": "a question about rust"}},
+            {"type": "assistant", "message": {"content": "an answer about rust"}}])
+        conn = self.indexed()
+        try:
+            self.assertEqual(len(recall.search(conn, "rust", limit=10)), 1)
+            self.assertEqual(recall.search(conn, "user rust", limit=10), [])
+        finally:
+            conn.close()
+
+
+class RebuildingAnOlderIndex(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.db = str(Path(tmp.name) / "old.db")
+
+    def old_index(self):
+        conn = sqlite3.connect(self.db)
+        conn.executescript(OLD_SCHEMA)
+        conn.execute("INSERT INTO messages VALUES ('gone', 'assistant', 'irreplaceable text')")
+        conn.execute("INSERT INTO messages_cjk VALUES ('gone', 'assistant', '日本語のテキスト')")
+        conn.commit()
+        return conn
+
+    def test_both_tables_are_rebuilt_without_losing_rows(self):
+        """From the rows already in them — sessions whose files were deleted
+        have nothing left to re-read."""
+        conn = self.old_index()
+        try:
+            with redirect_stderr(io.StringIO()):
+                recall.migrate_message_columns(conn)
+            for table in ("messages", "messages_cjk"):
+                self.assertIn("role UNINDEXED", conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE name = ?", (table,)).fetchone()[0])
+            self.assertEqual(conn.execute("SELECT text FROM messages").fetchone()[0],
+                             "irreplaceable text")
+            self.assertEqual(conn.execute("SELECT text FROM messages_cjk").fetchone()[0],
+                             "日本語のテキスト")
+            self.assertEqual(conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE messages MATCH 'assistant'").fetchone()[0], 0)
+            self.assertEqual(conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE messages MATCH 'irreplaceable'").fetchone()[0], 1)
+        finally:
+            conn.close()
+
+    def test_an_index_that_is_already_right_is_left_alone(self):
+        conn = sqlite3.connect(self.db)
+        try:
+            recall.create_schema(conn)
+            before = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'messages'").fetchone()[0]
+            recall.migrate_message_columns(conn)
+            self.assertEqual(conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'messages'").fetchone()[0], before)
+        finally:
+            conn.close()
+
+    def test_an_interrupted_rebuild_leaves_the_index_usable(self):
+        """It is one transaction, so a run killed part way through rolls back
+        rather than leaving a half-built table for the next run to die on."""
+        conn = self.old_index()
+        try:
+            class DiesPartWay:
+                def __init__(self, wrapped):
+                    self._wrapped = wrapped
+
+                def execute(self, sql, *args):
+                    if sql.strip().startswith("DROP TABLE messages"):
+                        raise KeyboardInterrupt("killed mid-rebuild")
+                    return self._wrapped.execute(sql, *args)
+
+                def __getattr__(self, name):
+                    return getattr(self._wrapped, name)
+
+            with redirect_stderr(io.StringIO()):
+                with self.assertRaises(KeyboardInterrupt):
+                    recall.migrate_message_columns(DiesPartWay(conn))
+
+            leftovers = [row[0] for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE name LIKE '%_rebuilt'")]
+            self.assertEqual(leftovers, [])
+            self.assertEqual(conn.execute("SELECT text FROM messages").fetchone()[0],
+                             "irreplaceable text")
+
+            with redirect_stderr(io.StringIO()):
+                recall.migrate_message_columns(conn)
+            self.assertIn("role UNINDEXED", conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'messages'").fetchone()[0])
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_role_column.py
+++ b/tests/test_role_column.py
@@ -138,6 +138,26 @@ class RebuildingAnOlderIndex(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_the_rebuild_runs_inside_the_index_lock(self):
+        """The rebuild takes seconds on a large index, past SQLite's busy
+        timeout, so main must only attempt it while holding the index lock —
+        otherwise a concurrent run dies with "database is locked", the crash
+        the lock exists to prevent. A run without the lock searches the old
+        schema, which still works."""
+        import inspect
+        src = inspect.getsource(recall.main)
+        self.assertIn("migrate_message_columns", src)
+        self.assertLess(src.index("with index_lock()"),
+                        src.index("migrate_message_columns"))
+
+        # And the old schema a lockless run is left searching still answers.
+        conn = self.old_index()
+        try:
+            self.assertEqual(conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE messages MATCH 'irreplaceable'").fetchone()[0], 1)
+        finally:
+            conn.close()
+
     def test_an_interrupted_rebuild_leaves_the_index_usable(self):
         """It is one transaction, so a run killed part way through rolls back
         rather than leaving a half-built table for the next run to die on."""


### PR DESCRIPTION
Independent of #15 and the earlier PRs.

## The bug

```python
CREATE VIRTUAL TABLE IF NOT EXISTS messages USING fts5(
    session_id UNINDEXED,
    role,          # <- indexed
    text,
    tokenize='porter unicode61'
);
```

`session_id` is `UNINDEXED` but `role` is not, and `role` holds the literal strings `user` and `assistant`. So those two words are searchable text on every row in the index.

On a 197,795-message index:

| query | rows matched | rows whose *text* contains the word |
|---|---|---|
| `MATCH 'assistant'` | **172,597** (87%) | 5,038 |
| `MATCH 'user'` | 45,983 | 15,809 |

## Why it matters beyond those two words

It silently corrupts any query containing them. `user rust` returns 6,046 rows where `rust` alone returns 12,795 — the term `user` doesn't narrow by meaning, it just restricts to `role='user'`. The user has no way to tell that happened.

Sampling excerpts over 30 real queries, 18 of 287 results contained neither a highlight nor any query term. All 18 came from the `user` and `assistant` queries; the other 28 queries were 0 for 267. Top hits for `user` include a message that is nothing but `[Image #1] [Image #2] …`.

## The fix

Mark `role` `UNINDEXED` on both `messages` and `messages_cjk`.

FTS5 column options can't be altered, so an existing index needs rebuilding. `migrate_message_columns` does it **from the rows already in the table** rather than re-reading transcripts — deliberately, because sessions whose files have since been deleted exist nowhere but the index. About 12 seconds for 198k messages, once, and it is skipped entirely once done.

It runs as one explicit transaction. `executescript` would commit each statement as it went, and a run killed during the rebuild would leave a half-built table that every later run then died on; there is a test for that case.

## Tests

`tests/test_role_column.py`, same conventions as the existing suite:

- a role name matches only messages whose text says it
- a role word does not narrow an ordinary query
- both tables rebuild without losing rows, CJK content included
- an index that is already correct is left untouched
- an interrupted rebuild rolls back cleanly and completes on the next run

I confirmed they catch it by putting `role` back — the suite fails. `python3 -m unittest discover tests -v` → 33 tests, OK.