### PR TITLE
Preserve indexed sessions during --reindex

### DIFF
--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -623,13 +623,6 @@ def parse_grok_session(path):
 
 def index_sessions(conn, force=False):
     """Scan and index new/changed session files from all sources."""
-    if force:
-        conn.executescript("""
-            DELETE FROM sessions;
-            DELETE FROM messages;
-            DELETE FROM messages_cjk;
-        """)
-
     # Get existing mtimes keyed by file_path (stable across session_id changes)
     existing = {}
     try:
@@ -678,13 +671,6 @@ def index_sessions(conn, force=False):
             skipped += 1
             continue
 
-        # Remove old data for this file if re-indexing
-        if fpath in existing:
-            old_sid = existing[fpath][0]
-            conn.execute("DELETE FROM sessions WHERE session_id = ?", (old_sid,))
-            conn.execute("DELETE FROM messages WHERE session_id = ?", (old_sid,))
-            conn.execute("DELETE FROM messages_cjk WHERE session_id = ?", (old_sid,))
-
         if source == "claude":
             result = parse_claude_session(fpath)
         elif source == "codex":
@@ -698,6 +684,14 @@ def index_sessions(conn, force=False):
             continue
 
         metadata, messages = result
+
+        # Replace this file only after it has been read successfully. Fall back
+        # to its parsed id for older rows that do not record a file path.
+        old_sid = (existing[fpath][0]
+                   if fpath in existing else metadata["session_id"])
+        conn.execute("DELETE FROM sessions WHERE session_id = ?", (old_sid,))
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (old_sid,))
+        conn.execute("DELETE FROM messages_cjk WHERE session_id = ?", (old_sid,))
 
         conn.execute(
             "INSERT OR REPLACE INTO sessions (session_id, source, file_path, project, slug, timestamp, mtime) VALUES (?, ?, ?, ?, ?, ?, ?)",

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -35,7 +35,8 @@ class RecencyBias(unittest.TestCase):
         for name, value in (("CLAUDE_DIR", self.root),
                             ("CLAUDE_PROJECTS_DIR", self.projects),
                             ("CODEX_SESSIONS_DIR", self.root / "none"),
-                            ("PI_SESSIONS_DIR", self.root / "none")):
+                            ("PI_SESSIONS_DIR", self.root / "none"),
+                            ("GROK_SESSIONS_DIR", self.root / "none")):
             self.addCleanup(setattr, recall, name, getattr(recall, name))
             setattr(recall, name, value)
 

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -1,0 +1,166 @@
+"""Tests that a forced reindex does not discard saved sessions."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Make scripts/ importable as a module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import recall  # noqa: E402
+
+
+class ReindexPreservesHistory(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.projects = self.root / "projects"
+        self.db = str(self.root / "index.db")
+
+        for name, value in (("CLAUDE_DIR", self.root),
+                            ("CLAUDE_PROJECTS_DIR", self.projects),
+                            ("CODEX_SESSIONS_DIR", self.root / "none"),
+                            ("PI_SESSIONS_DIR", self.root / "none"),
+                            ("GROK_SESSIONS_DIR", self.root / "none")):
+            self.addCleanup(setattr, recall, name, getattr(recall, name))
+            setattr(recall, name, value)
+
+    def session(self, name, text, mtime=1_800_000_000):
+        path = self.projects / "proj" / f"{name}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "type": "user",
+            "cwd": "/work",
+            "message": {"content": text},
+        }) + "\n", encoding="utf-8")
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def connect(self):
+        conn = sqlite3.connect(self.db)
+        recall.create_schema(conn)
+        recall.migrate_schema(conn)
+        return conn
+
+    def contents(self):
+        conn = sqlite3.connect(self.db)
+        try:
+            sessions = list(conn.execute(
+                "SELECT session_id, file_path FROM sessions ORDER BY session_id"))
+            messages = list(conn.execute(
+                "SELECT session_id, role, text FROM messages ORDER BY session_id, text"))
+            cjk = list(conn.execute(
+                "SELECT session_id, role, text FROM messages_cjk ORDER BY session_id, text"))
+            return sessions, messages, cjk
+        finally:
+            conn.close()
+
+    def test_reindex_keeps_a_session_whose_file_is_gone(self):
+        gone = self.session("gone", "irreplaceable history")
+        live = self.session("live", "before")
+        conn = self.connect()
+        try:
+            recall.index_sessions(conn)
+            gone.unlink()
+            self.session("live", "after")
+
+            recall.index_sessions(conn, force=True)
+
+            self.assertEqual(conn.execute(
+                "SELECT COUNT(*) FROM sessions").fetchone()[0], 2)
+            self.assertEqual(conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE text = 'irreplaceable history'"
+            ).fetchone()[0], 1)
+            self.assertEqual(conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE text = 'after'"
+            ).fetchone()[0], 1)
+            self.assertEqual(conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE text = 'before'"
+            ).fetchone()[0], 0)
+            self.assertTrue(live.exists())
+        finally:
+            conn.close()
+
+    def test_reindex_keeps_a_session_that_cannot_be_read(self):
+        path = self.session("unreadable", "saved before the read failed")
+        conn = self.connect()
+        try:
+            recall.index_sessions(conn)
+            with patch.object(recall, "parse_claude_session", return_value=None):
+                recall.index_sessions(conn, force=True)
+
+            self.assertEqual(conn.execute(
+                "SELECT text FROM messages WHERE session_id = ?",
+                (path.stem,),
+            ).fetchone()[0], "saved before the read failed")
+        finally:
+            conn.close()
+
+    def test_reindex_replaces_a_legacy_row_without_duplicating_it(self):
+        path = self.session("legacy", "current text")
+        conn = self.connect()
+        try:
+            conn.execute(
+                "INSERT INTO sessions "
+                "(session_id, source, file_path, project, slug, timestamp, mtime) "
+                "VALUES ('legacy', 'claude', '', '/work', 'legacy', 0, 0)"
+            )
+            conn.execute(
+                "INSERT INTO messages VALUES "
+                "('legacy', 'user', 'text from the old index')"
+            )
+            conn.commit()
+
+            recall.index_sessions(conn, force=True)
+
+            self.assertEqual(conn.execute(
+                "SELECT file_path FROM sessions WHERE session_id = 'legacy'"
+            ).fetchone()[0], str(path))
+            self.assertEqual(list(conn.execute(
+                "SELECT text FROM messages WHERE session_id = 'legacy'"
+            )), [("current text",)])
+        finally:
+            conn.close()
+
+    def test_an_interrupted_reindex_leaves_the_old_index_intact(self):
+        self.session("first", "old first")
+        self.session("second", "old second")
+        conn = self.connect()
+        recall.index_sessions(conn)
+        conn.close()
+        before = self.contents()
+
+        self.session("first", "new first")
+        self.session("second", "new second")
+        original = recall.parse_claude_session
+        calls = 0
+
+        def interrupt_second_file(path):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise KeyboardInterrupt("stopped during reindex")
+            return original(path)
+
+        conn = self.connect()
+        try:
+            with patch.object(recall, "parse_claude_session",
+                              side_effect=interrupt_second_file):
+                with self.assertRaises(KeyboardInterrupt):
+                    recall.index_sessions(conn, force=True)
+        finally:
+            conn.close()
+
+        self.assertEqual(self.contents(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_role_column.py
+++ b/tests/test_role_column.py
@@ -45,7 +45,8 @@ class RolesAreNotSearchable(unittest.TestCase):
         for name, value in (("CLAUDE_DIR", self.root),
                             ("CLAUDE_PROJECTS_DIR", self.projects),
                             ("CODEX_SESSIONS_DIR", self.root / "none"),
-                            ("PI_SESSIONS_DIR", self.root / "none")):
+                            ("PI_SESSIONS_DIR", self.root / "none"),
+                            ("GROK_SESSIONS_DIR", self.root / "none")):
             self.addCleanup(setattr, recall, name, getattr(recall, name))
             setattr(recall, name, value)
 


### PR DESCRIPTION
## Problem

#14 

`--reindex` empties the index before scanning disk. In my current index, 2,962 of 7,244 session rows point to files that are gone, so a rebuild deletes the only remaining copy of those conversations.

The up-front `executescript` also commits the deletes before the rebuild starts. A stopped rebuild leaves an empty index, and a file that cannot be read after the scan loses its old rows.

## Change

Read each live file before replacing its rows. A forced run still rereads every live file, while missing or unreadable sessions remain in place. The replacements stay in the same transaction, so an interrupted run rolls back. Falling back to the parsed session id keeps older rows with a blank `file_path` from being duplicated.

The first commit also keeps two indexer tests out of the real Grok session directory. They were reading live history on machines with Grok sessions.

## Tests

`python3 -m unittest discover tests -v`

64 tests pass, 1 skipped.